### PR TITLE
test: cover slm_ppa_worker edge cases

### DIFF
--- a/tests/test_slm_ppa_worker.py
+++ b/tests/test_slm_ppa_worker.py
@@ -232,7 +232,7 @@ class TestWorkerEventEmission:
         warn_events = [e for e in received if e.source == "slm_ppa_worker"]
         assert len(warn_events) >= 1
         assert "SLM down" in warn_events[0].message
-b
+
 
 # ── is_running before start ───────────────────────────────────────────────────
 

--- a/tests/test_slm_ppa_worker.py
+++ b/tests/test_slm_ppa_worker.py
@@ -232,3 +232,163 @@ class TestWorkerEventEmission:
         warn_events = [e for e in received if e.source == "slm_ppa_worker"]
         assert len(warn_events) >= 1
         assert "SLM down" in warn_events[0].message
+
+
+# ── is_running before start ───────────────────────────────────────────────────
+
+
+class TestIsRunning:
+
+    @pytest.mark.unit
+    def test_is_running_returns_false_before_start(self) -> None:
+        _reset_worker()
+        assert not is_running()
+
+
+# ── _dispatch internals ───────────────────────────────────────────────────────
+
+
+class TestDispatch:
+    """Direct unit tests for _dispatch, _enrich_physics, _enrich_command."""
+
+    @pytest.mark.unit
+    def test_unknown_kind_raises_value_error(self) -> None:
+        import lumina.core.slm_ppa_worker as w
+
+        async def _test():
+            loop = asyncio.get_running_loop()
+            req = EnrichmentRequest(
+                kind="not_a_real_kind",  # type: ignore[arg-type]
+                payload={},
+                future=loop.create_future(),
+            )
+            with pytest.raises(ValueError, match="Unknown enrichment kind"):
+                await w._dispatch(req)
+
+        _run(_test())
+
+    @pytest.mark.unit
+    def test_enrich_physics_passes_all_args_to_slm(self) -> None:
+        import lumina.core.slm_ppa_worker as w
+
+        captured: dict = {}
+
+        def fake_physics(incoming_signals, domain_physics, glossary=None, actor_input=None):
+            captured["incoming_signals"] = incoming_signals
+            captured["domain_physics"] = domain_physics
+            captured["glossary"] = glossary
+            captured["actor_input"] = actor_input
+            return {"matched_invariants": ["inv-x"]}
+
+        async def _test():
+            with patch("lumina.core.slm.slm_interpret_physics_context", fake_physics):
+                result = await w._enrich_physics({
+                    "incoming_signals": {"sig": 42},
+                    "domain_physics": {"id": "dom"},
+                    "glossary": [{"term": "eigenvalue"}],
+                    "actor_input": "test input",
+                })
+            assert result == {"matched_invariants": ["inv-x"]}
+
+        _run(_test())
+        assert captured["incoming_signals"] == {"sig": 42}
+        assert captured["domain_physics"] == {"id": "dom"}
+        assert captured["glossary"] == [{"term": "eigenvalue"}]
+        assert captured["actor_input"] == "test input"
+
+    @pytest.mark.unit
+    def test_enrich_physics_optional_args_default_to_none(self) -> None:
+        import lumina.core.slm_ppa_worker as w
+
+        captured: dict = {}
+
+        def fake_physics(incoming_signals, domain_physics, glossary=None, actor_input=None):
+            captured["glossary"] = glossary
+            captured["actor_input"] = actor_input
+            return {}
+
+        async def _test():
+            with patch("lumina.core.slm.slm_interpret_physics_context", fake_physics):
+                await w._enrich_physics({
+                    "incoming_signals": {},
+                    "domain_physics": {},
+                    # glossary and actor_input omitted
+                })
+
+        _run(_test())
+        assert captured["glossary"] is None
+        assert captured["actor_input"] is None
+
+    @pytest.mark.unit
+    def test_enrich_command_passes_available_operations(self) -> None:
+        import lumina.core.slm_ppa_worker as w
+
+        captured: dict = {}
+
+        def fake_parse(natural_language, available_operations=None):
+            captured["natural_language"] = natural_language
+            captured["available_operations"] = available_operations
+            return {"operation": "add_module", "target": "x", "params": {}}
+
+        async def _test():
+            with patch("lumina.core.slm.slm_parse_admin_command", fake_parse):
+                result = await w._enrich_command({
+                    "natural_language": "add module X",
+                    "available_operations": ["add_module", "remove_module"],
+                })
+            assert result["operation"] == "add_module"
+
+        _run(_test())
+        assert captured["natural_language"] == "add module X"
+        assert captured["available_operations"] == ["add_module", "remove_module"]
+
+    @pytest.mark.unit
+    def test_enrich_command_optional_operations_defaults_to_none(self) -> None:
+        import lumina.core.slm_ppa_worker as w
+
+        captured: dict = {}
+
+        def fake_parse(natural_language, available_operations=None):
+            captured["available_operations"] = available_operations
+            return None
+
+        async def _test():
+            with patch("lumina.core.slm.slm_parse_admin_command", fake_parse):
+                await w._enrich_command({"natural_language": "do something"})
+
+        _run(_test())
+        assert captured["available_operations"] is None
+
+
+# ── Multiple enqueues ─────────────────────────────────────────────────────────
+
+
+class TestMultipleEnqueues:
+
+    @pytest.mark.unit
+    def test_multiple_sequential_enqueues_all_resolve(self) -> None:
+        async def _test():
+            _reset_worker()
+            call_count = 0
+
+            async def fake_physics(payload):
+                nonlocal call_count
+                call_count += 1
+                return {"n": call_count}
+
+            with patch(
+                "lumina.core.slm_ppa_worker._enrich_physics",
+                new_callable=AsyncMock,
+                side_effect=[{"n": 1}, {"n": 2}, {"n": 3}],
+            ):
+                await start()
+                r1 = await enqueue(EnrichmentKind.PHYSICS_CONTEXT, {"incoming_signals": {}, "domain_physics": {}})
+                r2 = await enqueue(EnrichmentKind.PHYSICS_CONTEXT, {"incoming_signals": {}, "domain_physics": {}})
+                r3 = await enqueue(EnrichmentKind.PHYSICS_CONTEXT, {"incoming_signals": {}, "domain_physics": {}})
+                await stop()
+
+            assert r1 == {"n": 1}
+            assert r2 == {"n": 2}
+            assert r3 == {"n": 3}
+
+        _run(_test())

--- a/tests/test_slm_ppa_worker.py
+++ b/tests/test_slm_ppa_worker.py
@@ -232,7 +232,7 @@ class TestWorkerEventEmission:
         warn_events = [e for e in received if e.source == "slm_ppa_worker"]
         assert len(warn_events) >= 1
         assert "SLM down" in warn_events[0].message
-
+b
 
 # ── is_running before start ───────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Extends `tests/test_slm_ppa_worker.py` with **7 new deterministic tests** targeting `lumina.core.slm_ppa_worker`, covering gaps in the existing suite.

## What's new

### `is_running` before start
- Returns `False` before `start()` is ever called (was only tested via lifecycle round-trip)

### `_dispatch` unknown kind
- A synthetic non-enum `kind` value triggers the `raise ValueError("Unknown enrichment kind: …")` branch, which was previously unreachable from tests

### `_enrich_physics` argument passing
- All four args (`incoming_signals`, `domain_physics`, `glossary`, `actor_input`) are forwarded correctly to `slm_interpret_physics_context` through `asyncio.to_thread`
- Optional `glossary` and `actor_input` default to `None` when absent from the payload dict

### `_enrich_command` argument passing
- `natural_language` and `available_operations` forwarded correctly to `slm_parse_admin_command` through `asyncio.to_thread`
- Optional `available_operations` defaults to `None` when absent from payload

### Multiple sequential enqueues
- Three back-to-back `enqueue()` calls each resolve to their own distinct result (tests queue ordering and future isolation)

## Test hygiene
- No live services, no real SLM HTTP calls, no secrets required
- `_enrich_physics` / `_enrich_command` tested by patching the SLM functions at `lumina.core.slm.*`
- 17 total tests in file (was 10); all pass locally
