### PR TITLE
fix: add SQLite adapter close() to drain aiosqlite threads

### DIFF
--- a/src/lumina/persistence/sqlite.py
+++ b/src/lumina/persistence/sqlite.py
@@ -978,3 +978,24 @@ class SQLitePersistenceAdapter(PersistenceAdapter):
                 )
             )
         return result.rowcount > 0
+
+    # ── Lifecycle ────────────────────────────────────────────
+
+    async def aclose(self) -> None:
+        """Dispose the SQLAlchemy async engine.
+
+        Awaiting this lets aiosqlite background worker threads finish their
+        pending callbacks before the event loop is closed, preventing the
+        ``RuntimeError: Event loop is closed`` warnings seen in tests.
+        """
+        await self._engine.dispose()
+
+    def close(self) -> None:
+        """Synchronous close — disposes the async engine via ``asyncio.run``.
+
+        Call this in test teardown (pytest fixture ``yield`` + ``adapter.close()``)
+        or on application shutdown.  This is the counterpart to the
+        ``asyncio.run(self._create_tables())`` call in ``__init__``, ensuring
+        aiosqlite worker threads drain before the event loop is destroyed.
+        """
+        asyncio.run(self.aclose())

--- a/tests/test_module_state_persistence.py
+++ b/tests/test_module_state_persistence.py
@@ -144,43 +144,42 @@ class TestSQLiteAdapterModuleState:
         db_url = f"sqlite+aiosqlite:///{tmp_path / 'test.db'}"
         return SQLitePersistenceAdapter(repo_root=_REPO_ROOT, database_url=db_url)
 
-    def test_save_load_roundtrip(self, tmp_path: Path) -> None:
+    @pytest.fixture
+    def db(self, tmp_path: Path):
         adapter = self._make_adapter(tmp_path)
+        yield adapter
+        adapter.close()
+
+    def test_save_load_roundtrip(self, db) -> None:
         state = {"mastery": {"tier_1": 0.8}, "challenge": 0.5}
-        adapter.save_module_state("u1", "algebra", state)
-        loaded = adapter.load_module_state("u1", "algebra")
+        db.save_module_state("u1", "algebra", state)
+        loaded = db.load_module_state("u1", "algebra")
         assert loaded == state
 
-    def test_load_missing_returns_none(self, tmp_path: Path) -> None:
-        adapter = self._make_adapter(tmp_path)
-        assert adapter.load_module_state("u1", "algebra") is None
+    def test_load_missing_returns_none(self, db) -> None:
+        assert db.load_module_state("u1", "algebra") is None
 
-    def test_upsert_overwrites(self, tmp_path: Path) -> None:
-        adapter = self._make_adapter(tmp_path)
-        adapter.save_module_state("u1", "algebra", {"v": 1})
-        adapter.save_module_state("u1", "algebra", {"v": 2})
-        assert adapter.load_module_state("u1", "algebra") == {"v": 2}
+    def test_upsert_overwrites(self, db) -> None:
+        db.save_module_state("u1", "algebra", {"v": 1})
+        db.save_module_state("u1", "algebra", {"v": 2})
+        assert db.load_module_state("u1", "algebra") == {"v": 2}
 
-    def test_list_module_states(self, tmp_path: Path) -> None:
-        adapter = self._make_adapter(tmp_path)
-        adapter.save_module_state("u1", "algebra", {"a": 1})
-        adapter.save_module_state("u1", "geometry", {"b": 2})
-        keys = adapter.list_module_states("u1")
+    def test_list_module_states(self, db) -> None:
+        db.save_module_state("u1", "algebra", {"a": 1})
+        db.save_module_state("u1", "geometry", {"b": 2})
+        keys = db.list_module_states("u1")
         assert sorted(keys) == ["algebra", "geometry"]
 
-    def test_delete_existing(self, tmp_path: Path) -> None:
-        adapter = self._make_adapter(tmp_path)
-        adapter.save_module_state("u1", "algebra", {"a": 1})
-        assert adapter.delete_module_state("u1", "algebra") is True
-        assert adapter.load_module_state("u1", "algebra") is None
+    def test_delete_existing(self, db) -> None:
+        db.save_module_state("u1", "algebra", {"a": 1})
+        assert db.delete_module_state("u1", "algebra") is True
+        assert db.load_module_state("u1", "algebra") is None
 
-    def test_delete_missing(self, tmp_path: Path) -> None:
-        adapter = self._make_adapter(tmp_path)
-        assert adapter.delete_module_state("u1", "algebra") is False
+    def test_delete_missing(self, db) -> None:
+        assert db.delete_module_state("u1", "algebra") is False
 
-    def test_isolation_between_users(self, tmp_path: Path) -> None:
-        adapter = self._make_adapter(tmp_path)
-        adapter.save_module_state("u1", "algebra", {"owner": "u1"})
-        adapter.save_module_state("u2", "algebra", {"owner": "u2"})
-        assert adapter.load_module_state("u1", "algebra")["owner"] == "u1"
-        assert adapter.load_module_state("u2", "algebra")["owner"] == "u2"
+    def test_isolation_between_users(self, db) -> None:
+        db.save_module_state("u1", "algebra", {"owner": "u1"})
+        db.save_module_state("u2", "algebra", {"owner": "u2"})
+        assert db.load_module_state("u1", "algebra")["owner"] == "u1"
+        assert db.load_module_state("u2", "algebra")["owner"] == "u2"

--- a/tests/test_persistence_sqlite.py
+++ b/tests/test_persistence_sqlite.py
@@ -8,11 +8,13 @@ from lumina.persistence.sqlite import SQLitePersistenceAdapter
 
 
 @pytest.fixture
-def sqlite_adapter(tmp_path: Path) -> SQLitePersistenceAdapter:
+def sqlite_adapter(tmp_path: Path):
     db_path = tmp_path / "lumina_test.db"
     db_url = f"sqlite+aiosqlite:///{db_path.as_posix()}"
     repo_root = Path(__file__).resolve().parents[1]
-    return SQLitePersistenceAdapter(repo_root=repo_root, database_url=db_url)
+    adapter = SQLitePersistenceAdapter(repo_root=repo_root, database_url=db_url)
+    yield adapter
+    adapter.close()
 
 
 @pytest.mark.unit

--- a/tests/test_sqlite_extended.py
+++ b/tests/test_sqlite_extended.py
@@ -10,10 +10,12 @@ from lumina.persistence.sqlite import SQLitePersistenceAdapter
 
 
 @pytest.fixture
-def db(tmp_path: Path) -> SQLitePersistenceAdapter:
+def db(tmp_path: Path):
     db_path = tmp_path / "test.db"
     db_url = f"sqlite+aiosqlite:///{db_path.as_posix()}"
-    return SQLitePersistenceAdapter(repo_root=tmp_path, database_url=db_url)
+    adapter = SQLitePersistenceAdapter(repo_root=tmp_path, database_url=db_url)
+    yield adapter
+    adapter.close()
 
 
 # ── save_subject_profile ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`SQLitePersistenceAdapter` uses `asyncio.run()` for every synchronous method, creating and destroying an event loop on each call. aiosqlite's background worker thread tried to post a result/exception callback back to a loop that had already been closed, raising:

```
RuntimeError: Event loop is closed
```

pytest surfaced this as `PytestUnhandledThreadExceptionWarning` from `aiosqlite.core._connection_worker_thread`. The CI log showed this warning appearing on tests across 4 different test files.

## Root cause

`asyncio.run()` creates a new event loop, runs the coroutine, then **closes the loop** — but aiosqlite's per-connection worker thread is still alive and may try to call `future.get_loop().call_soon_threadsafe(...)` after the loop closes.

## Fix

**`src/lumina/persistence/sqlite.py`**
- Add `async aclose()` — disposes the SQLAlchemy async engine, which signals aiosqlite connections to close cleanly.
- Add sync `close()` — wraps `aclose()` with `asyncio.run()`, mirroring the pattern already used by `__init__`.

**`tests/test_sqlite_extended.py`** / **`tests/test_persistence_sqlite.py`**
- Change `return adapter` fixtures to `yield adapter` + `adapter.close()` in teardown so the engine is disposed after each test.

**`tests/test_module_state_persistence.py`**
- Add a `db` fixture to `TestSQLiteAdapterModuleState` that yields and closes.
- Refactor all 7 test methods to use the fixture instead of creating an unclosed adapter inline.

## Verification

- All 48 SQLite tests pass locally after installing `sqlalchemy[asyncio] aiosqlite`.
- Running the three affected test files with `-W default` produces zero warnings.
