### PR TITLE
fix: move TestManifestCoverage.manifest to module-scope fixture

### DIFF
--- a/tests/test_schema_versioning.py
+++ b/tests/test_schema_versioning.py
@@ -102,14 +102,17 @@ class TestDocsFrontmatter:
 
 # ── MANIFEST coverage ───────────────────────────────────────────────────────
 
+
+@pytest.fixture(scope="class")
+def manifest() -> dict:
+    """Load MANIFEST.yaml once per test class."""
+    path = REPO_ROOT / "docs" / "MANIFEST.yaml"
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
 @pytest.mark.unit
 class TestManifestCoverage:
     """MANIFEST.yaml must track all core artifacts and have valid metadata."""
-
-    @pytest.fixture(scope="class")
-    def manifest(self) -> dict:
-        path = REPO_ROOT / "docs" / "MANIFEST.yaml"
-        return yaml.safe_load(path.read_text(encoding="utf-8"))
 
     def test_has_schema_version(self, manifest):
         assert "schema_version" in manifest


### PR DESCRIPTION
## Problem

pytest 10 deprecates class-scoped fixtures defined as instance methods:

```
PytestRemovedIn10Warning: Class-scoped fixture defined as instance method is deprecated.
Instance attributes set in this fixture will NOT be visible to test methods,
as each test gets a new instance while the fixture runs only once per class.
```

This was triggered by `TestManifestCoverage.manifest` in `tests/test_schema_versioning.py`.

## Fix

Move the `manifest` fixture out of the class body to module scope. The fixture still has `scope="class"` so it runs once per class and is injected as a parameter as before — the only change is its location.

```python
# Before (deprecated):
class TestManifestCoverage:
    @pytest.fixture(scope="class")
    def manifest(self) -> dict:
        ...

# After:
@pytest.fixture(scope="class")
def manifest() -> dict:
    ...

class TestManifestCoverage:
    ...
```

## Verification

All 975 tests in the file pass locally with no `PytestRemovedIn10Warning`.
