### PR TITLE
fix: suppress Starlette/httpx TestClient deprecation warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,8 @@ markers =
     integration: integration tests across modules/services
     e2e: end-to-end flow tests
     slow: long-running tests
+filterwarnings =
+    # Starlette 1.x prefers httpx2 for TestClient; suppress until httpx2 is
+    # adopted as a dev dependency.  This is a third-party compatibility warning
+    # and not a repo code issue.
+    ignore:Using `httpx` with `starlette.testclient`:starlette.exceptions.StarletteDeprecationWarning


### PR DESCRIPTION
## Problem

Starlette 1.x emits `StarletteDeprecationWarning` when `TestClient` is imported with `httpx` instead of the newer `httpx2` package:

```
StarletteDeprecationWarning: Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.
```

This appeared in every test file that imports `TestClient` from `fastapi.testclient`.

## Why not switch to httpx2?

Production code uses `httpx` directly for SLM HTTP calls (`_call_local_slm`). Switching to `httpx2` in dev-only test client imports while keeping `httpx` for production would mean maintaining two HTTP client packages as runtime dependencies — an unnecessary split.

The correct long-term resolution is for FastAPI/Starlette to resolve this upstream, or for the project to migrate httpx → httpx2 in a dedicated dependency upgrade PR that tests all SLM transport paths.

## Fix

Add a narrow `filterwarnings` entry in `pytest.ini` that matches the exact warning message and class (`starlette.exceptions.StarletteDeprecationWarning`) so it is suppressed in CI output without hiding any repo-owned warnings.

A comment in the config records the upstream reason so the filter can be removed cleanly once the dependency situation is resolved.

## Verification

Running `tests/test_multi_domain.py` and `tests/test_sse_and_events.py` without `-W default` override shows no warnings in output.
