### PR TITLE
chore: add base_framework and reference_pack pytest markers

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -6,6 +6,8 @@ markers =
     integration: integration tests across modules/services
     e2e: end-to-end flow tests
     slow: long-running tests
+    base_framework: tests for core engine, runtime loader, domain registry, routing, and base model-packs (system, template)
+    reference_pack: tests for provisional/reference packs (education, agriculture, assistant) — not core framework infra
 filterwarnings =
     # Starlette 1.x prefers httpx2 for TestClient; suppress until httpx2 is
     # adopted as a dev dependency.  This is a third-party compatibility warning


### PR DESCRIPTION
## Context

Adds two new pytest markers that reflect the framework boundary defined in [`docs/7-concepts/framework-boundary.md`](docs/7-concepts/framework-boundary.md):

| Marker | Applied To |
|--------|-----------|
| `base_framework` | Tests for the core engine, runtime loader, domain registry, routing, and the three base model-packs (system, template, coding-agent skeleton) |
| `reference_pack` | Tests for provisional/reference packs (education, agriculture, assistant) — domain examples, not core infra |

## Why Now

- `model-packs/README.md` was just updated (PR #47) to document this boundary clearly.
- The markers will be used to slice CI runs and make it trivial to identify which tests are validating framework contracts vs which are validating reference domain behavior.
- Registering the markers now means any `@pytest.mark.base_framework` / `@pytest.mark.reference_pack` applied going forward will not trigger `PytestUnknownMarkWarning`.

## No Tests Tagged Yet

This is the taxonomy step only. Individual test tagging follows in subsequent PRs as new test suites are added.

## Files Changed
- `pytest.ini` — +2 lines