### PR TITLE
fix: replace sys.argv[0] with __file__ in system_log_validator default log-dir

### DIFF
--- a/model-packs/system/controllers/system_log_validator.py
+++ b/model-packs/system/controllers/system_log_validator.py
@@ -486,7 +486,7 @@ def main() -> None:
     parser.add_argument(
         "--log-dir",
         metavar="DIR",
-        default=os.environ.get("LUMINA_LOG_DIR", str(Path(sys.argv[0]).resolve().parents[3] / "ctl")),
+        default=os.environ.get("LUMINA_LOG_DIR", str(Path(__file__).resolve().parents[3] / "ctl")),
         help="System Log root directory (for --verify-system-chain). Defaults to LUMINA_LOG_DIR env var.",
     )
     parser.add_argument(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,4 +69,6 @@ packages = ["src/lumina"]
 [tool.coverage.run]
 omit = [
     "*/systools/dsa_demo.py",
+    "*/systools/ppa_demo.py",
+    "*/controllers/ppa_demo.py",
 ]


### PR DESCRIPTION
## Bug

`system_log_validator.py` uses `Path(sys.argv[0]).resolve().parents[3]` as the default value for `--log-dir`.  When `sys.argv[0]` is a bare command name (e.g. `"ctl_validator"` as set by the test harness, or just `"python"` in some invocations), the resolved path has **fewer than 4 parent levels**, causing:

```
IndexError: 3
```

This broke 6 tests in `test_system_log_validator_extended.py`.

## Fix

Replace `sys.argv[0]` with `__file__`.

The module is at `model-packs/system/controllers/system_log_validator.py`, so `Path(__file__).resolve().parents[3]` is always the repo root — regardless of how the script is invoked.  The `/ "ctl"` suffix correctly produces `<repo-root>/ctl`.

## Also: ppa_demo.py coverage omit

`ppa_demo.py` (both the `src/lumina/systools/` shim and the canonical `model-packs/system/controllers/` copy) are **runnable developer documentation** — a self-contained CLI demo of the PPA activation/physics-propagation cycle. They are intentionally at 0% coverage, same policy as `dsa_demo.py`. Both are now excluded from `[tool.coverage.run] omit`.

## Files Changed
- `model-packs/system/controllers/system_log_validator.py` — 1-line fix (`sys.argv[0]` → `__file__`)
- `pyproject.toml` — add two `ppa_demo.py` omit patterns