### PR TITLE
chore: ratchet backend coverage gate to 82% and omit app-factory files

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -31,15 +31,17 @@ jobs:
       - name: Secret hygiene check
         run: bash scripts/check-local-secret-hygiene.sh
 
-      # Coverage ratchet: baseline was ~69.96% (PR #37). Raised to 72% after
-      # targeted test-hardening in PR #40. Continue raising toward 85% through
-      # focused test-hardening PRs; do not lower this threshold.
-      - name: Backend tests + coverage gate (>=72%)
+      # Coverage ratchet history:
+      #   ~69.96% baseline (PR #37) → 72% (PR #40) → 82% (PR O, 2026-06-19)
+      # Current baseline: ~82.04% on Python 3.13 (after PRs H, N, O omit hygiene).
+      # Continue raising toward 85% through focused test-hardening PRs;
+      # do not lower this threshold.
+      - name: Backend tests + coverage gate (>=82%)
         run: >
           python -m pytest tests -q
           --cov=lumina
           --cov-report=term-missing
-          --cov-fail-under=72
+          --cov-fail-under=82
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,15 @@ packages = ["src/lumina"]
 
 [tool.coverage.run]
 omit = [
+    # Executable developer documentation — not product code
     "*/systools/dsa_demo.py",
     "*/systools/ppa_demo.py",
     "*/controllers/ppa_demo.py",
+    # Thin FastAPI app-factory/import glue — behavior is in the route modules
+    "*/services/admin/app.py",
+    "*/services/auth/app.py",
+    "*/services/dashboard/app.py",
+    "*/services/domain/app.py",
+    "*/services/ingestion/app.py",
+    "*/services/system_log/app.py",
 ]


### PR DESCRIPTION
## Gate ratchet

`--cov-fail-under` raises from 72 → **82**.

Current CI baseline on merged `main` (Python 3.13): **~82.04%** after PRs H (delete `server_original.py`), N (fix `system_log_validator` + ppa_demo omit), and K/50 (pipeline helper tests).

Ratchet history is preserved in the CI job comment:
> ~69.96% (PR #37) → 72% (PR #40) → **82%** (PR O, 2026-06-19)

---

## Coverage omit additions

Six thin FastAPI app-factory files added to `[tool.coverage.run] omit` in `pyproject.toml`:

```
*/services/admin/app.py
*/services/auth/app.py
*/services/dashboard/app.py
*/services/domain/app.py
*/services/ingestion/app.py
*/services/system_log/app.py
```

Each of these files is a ~8-line pattern of `create_app() → FastAPI() → include_router() → app = create_app()`. They have **zero testable logic** — behavior lives in the route modules they mount. Those route modules remain measured.

This follows the same omit policy as `dsa_demo.py` and `ppa_demo.py`.

---

## What is NOT omitted

All route modules, middleware, persistence, pipeline, orchestrator, and utility modules stay in the coverage denominator and will receive tests in PRs P through Y.