### PR TITLE
feat(coding-agent): Slice 8 job intake + micro-context

### DIFF
--- a/docs/MANIFEST.yaml
+++ b/docs/MANIFEST.yaml
@@ -1630,6 +1630,18 @@ artifacts:
   status: active
   last_updated: 2026-06-28
   sha256: 83bfef3bdbdbb691900950b26334ae0a85dafadcf3f98409dfb9146fbe7928e7
+- path: model-packs/coding-agent/domain-lib/job_intake.py
+  type: code
+  doc_version: 0.1.0
+  status: active
+  last_updated: 2026-06-28
+  sha256: 0476461c73b048535e10ccce821a505ebff0bab92f7eefd3d5b60431cf97cb42
+- path: model-packs/coding-agent/domain-lib/micro_context.py
+  type: code
+  doc_version: 0.1.0
+  status: active
+  last_updated: 2026-06-28
+  sha256: 342a8794d1187b65b68630d1b2fa78200830506784fb7fc6ddaaed56ad455086
 - path: model-packs/coding-agent/modules/core/tool-adapters/read-file-adapter-v1.yaml
   type: config
   doc_version: 0.1.0

--- a/model-packs/coding-agent/controllers/nlp_pre_interpreter.py
+++ b/model-packs/coding-agent/controllers/nlp_pre_interpreter.py
@@ -18,9 +18,55 @@ def pre_interpret(input_text: str, context: dict[str, Any] | None = None) -> dic
     """Extract cheap authority-boundary signals before SLM interpretation."""
     text = input_text.lower()
     requested_files = [token for token in input_text.split() if "/" in token or "\\" in token]
+    job_validation = None
+    micro_context = None
+    # Attempt to discover a job payload in the provided context or a JSON block
+    job_payload = None
+    if context:
+        job_payload = context.get("job") or context.get("job_payload")
+
+    # Try to extract a JSON object from fenced code or inline JSON in the input
+    if job_payload is None and "{" in input_text:
+        try:
+            import json
+
+            # crude extraction: take the first {...} substring
+            start = input_text.index("{")
+            end = input_text.rindex("}")
+            candidate = input_text[start : end + 1]
+            job_payload = json.loads(candidate)
+        except Exception:
+            job_payload = None
+
+    # Load domain-lib helpers via file-based import to avoid package name issues
+    if job_payload is not None:
+        try:
+            import importlib.util
+            from pathlib import Path
+
+            base = Path(__file__).resolve().parents[1] / "domain-lib"
+            job_intake_path = str(base / "job_intake.py")
+            micro_ctx_path = str(base / "micro_context.py")
+
+            spec = importlib.util.spec_from_file_location("coding.job_intake", job_intake_path)
+            job_mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(job_mod)  # type: ignore[arg-type]
+
+            spec2 = importlib.util.spec_from_file_location("coding.micro_context", micro_ctx_path)
+            mc_mod = importlib.util.module_from_spec(spec2)
+            spec2.loader.exec_module(mc_mod)  # type: ignore[arg-type]
+
+            vres = job_mod.validate_job(job_payload)
+            job_validation = {"valid": vres.valid, "errors": vres.errors, "normalized": vres.normalized}
+            micro_context = mc_mod.build_micro_context(vres.normalized)
+        except Exception:
+            job_validation = {"valid": False, "errors": ["validation-failed"], "normalized": {}}
+
     return {
         "authority_boundary_hint": any(term in text for term in BOUNDARY_TERMS),
         "mentions_patch": any(term in text for term in ("patch", "diff", "edit", "modify")),
         "mentions_tests": any(term in text for term in ("test", "pytest", "validate", "ci")),
         "requested_files": requested_files,
+        "job_validation": job_validation,
+        "micro_context": micro_context,
     }

--- a/model-packs/coding-agent/controllers/runtime_adapters.py
+++ b/model-packs/coding-agent/controllers/runtime_adapters.py
@@ -42,8 +42,12 @@ def domain_step(
     new_state = dict(state)
     new_state["turn_count"] = int(new_state.get("turn_count", 0)) + 1
 
-    boundary_violation = bool(evidence.get("authority_boundary_violation", False))
-    scope_valid = bool(evidence.get("job_scope_valid", False))
+    # Prefer micro-context if provided by the pre-interpreter
+    micro = evidence.get("micro_context") if isinstance(evidence.get("micro_context"), dict) else None
+    boundary_violation = bool(evidence.get("authority_boundary_violation", False)) or bool(
+        micro and micro.get("authority_boundary")
+    )
+    scope_valid = bool(evidence.get("job_scope_valid", False)) or bool(micro and micro.get("scope_valid"))
     patch_generated = bool(evidence.get("patch_generated", False))
     tests_passed = evidence.get("tests_passed")
 

--- a/model-packs/coding-agent/domain-lib/job_intake.py
+++ b/model-packs/coding-agent/domain-lib/job_intake.py
@@ -1,0 +1,51 @@
+"""Job intake validation utilities for the coding-agent pack.
+
+This module implements lightweight, deterministic validation suitable for
+pre-interpreter checks and micro-context construction. Keep logic pure and
+free of external side-effects so the runtime adapter can call it safely.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class ValidationResult:
+    def __init__(self, valid: bool, errors: list[str], normalized: dict[str, Any]):
+        self.valid = valid
+        self.errors = errors
+        self.normalized = normalized
+
+
+def validate_job(payload: dict[str, Any]) -> ValidationResult:
+    """Validate a job payload (best-effort).
+
+    Rules (minimal, conservative):
+    - `title`: required, non-empty string
+    - `description`: required, >= 10 chars
+    - `priority`: optional, one of ('low','normal','high')
+    """
+    errors: list[str] = []
+    if not isinstance(payload, dict):
+        return ValidationResult(False, ["payload-not-dict"], {})
+
+    title = payload.get("title")
+    if not title or not isinstance(title, str) or not title.strip():
+        errors.append("missing-or-invalid-title")
+
+    description = payload.get("description")
+    if not description or not isinstance(description, str) or len(description.strip()) < 10:
+        errors.append("missing-or-short-description")
+
+    priority = payload.get("priority")
+    if priority is not None and priority not in ("low", "normal", "high"):
+        errors.append("invalid-priority")
+
+    normalized = {
+        "title": (title or "").strip() if isinstance(title, str) else "",
+        "description": (description or "").strip() if isinstance(description, str) else "",
+        "priority": priority or "normal",
+        "files": list(payload.get("files") or []),
+    }
+
+    return ValidationResult(valid=(len(errors) == 0), errors=errors, normalized=normalized)

--- a/model-packs/coding-agent/domain-lib/micro_context.py
+++ b/model-packs/coding-agent/domain-lib/micro_context.py
@@ -1,0 +1,33 @@
+"""Micro-context builder for coding-agent job turns.
+
+Produces a compact, deterministic micro-context dictionary from a
+validated job payload and optional runtime metadata. The runtime adapter
+consumes the `tier` field for routing decisions.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+
+def build_micro_context(validated_job: dict[str, Any], extras: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Build a micro-context using the normalized job dict.
+
+    `validated_job` should be the `normalized` dict returned by
+    `job_intake.validate_job(...).normalized`.
+    """
+    priority = (validated_job or {}).get("priority") or "normal"
+    tier_map = {"high": "critical", "normal": "ok", "low": "minor"}
+    tier = tier_map.get(priority, "ok")
+
+    files = list(validated_job.get("files") or [])
+
+    return {
+        "job_id": (validated_job.get("title")[:64] if validated_job.get("title") else None),
+        "tier": tier,
+        "scope_valid": bool(validated_job.get("title") and validated_job.get("description")),
+        "files": files,
+        "created_at": datetime.utcnow().isoformat() + "Z",
+        "extras": extras or {},
+    }

--- a/tests/test_coding_agent_job_intake.py
+++ b/tests/test_coding_agent_job_intake.py
@@ -1,0 +1,43 @@
+import json
+from pathlib import Path
+import importlib.util
+
+
+BASE = Path(__file__).resolve().parents[1] / "model-packs" / "coding-agent" / "domain-lib"
+
+
+def _load(mod_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(mod_name, str(path))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore
+    return mod
+
+
+def test_validate_job_ok():
+    job_mod = _load("job_intake", BASE / "job_intake.py")
+    payload = {"title": "Add README", "description": "Add a README explaining usage.", "priority": "normal"}
+    res = job_mod.validate_job(payload)
+    assert res.valid
+    assert res.normalized["priority"] == "normal"
+
+
+def test_validate_job_missing_fields():
+    job_mod = _load("job_intake", BASE / "job_intake.py")
+    payload = {"title": "", "description": "short"}
+    res = job_mod.validate_job(payload)
+    assert not res.valid
+    assert "missing-or-invalid-title" in res.errors
+
+
+def test_pre_interpret_extracts_micro_context():
+    pre_mod_path = Path(__file__).resolve().parents[1] / "model-packs" / "coding-agent" / "controllers" / "nlp_pre_interpreter.py"
+    pre_mod = _load("nlp_pre", pre_mod_path)
+
+    job_payload = {"title": "Refactor", "description": "Refactor module for clarity", "priority": "high"}
+    input_text = "Please do this job: " + json.dumps(job_payload)
+    result = pre_mod.pre_interpret(input_text, context=None)
+
+    assert result.get("job_validation") is not None
+    assert result.get("micro_context") is not None
+    assert result["job_validation"]["valid"]
+    assert result["micro_context"]["tier"] == "critical"


### PR DESCRIPTION
Implements Slice 8: job intake validation and micro-context builder for the coding-agent pack. Adds domain-lib modules `job_intake.py` and `micro_context.py`, wires `nlp_pre_interpreter` to produce micro-context, updates `runtime_adapters.domain_step` to prefer micro-context routing, and adds tests. Manifest was regenerated to include new files.