### PR TITLE
docs(roadmap): mark Slices 7-8 delivered; add Slice 9 plan; update coding-agent CHANGELOG

### DIFF
--- a/docs/MANIFEST.yaml
+++ b/docs/MANIFEST.yaml
@@ -1768,7 +1768,7 @@ artifacts:
   doc_version: 1.0.0
   status: active
   last_updated: 2026-06-18
-  sha256: a8cfa214aa21f3ae37477dba37b060adba6fbc647c16a6d1610b571e75d8de14
+  sha256: ea8cbaedc33cc75a8189af6a74424e677b0a9758610141622147960c70f55b0b
 - path: docs/roadmap/slices/01-framework-boundary.md
   type: doc
   doc_version: 1.0.0
@@ -1809,4 +1809,16 @@ artifacts:
   doc_version: 1.0.0
   status: active
   last_updated: 2026-06-28
-  sha256: a9c4ba94f5f1206a59a9108f37a60d4a1c7ba336f37b3763d2f387f119a968fa
+  sha256: 8eabd7b56db607a7bc850a4b6c8863188319bbbc229ba4a695aabce3181efa0e
+- path: docs/roadmap/slices/08-job-intake-micro-context.md
+  type: doc
+  doc_version: 1.0.0
+  status: active
+  last_updated: 2026-06-28
+  sha256: ffdf2dc22747ea453c79b340264a4674c0a0730832b5c61621d703fd8cf49561
+- path: docs/roadmap/slices/09-context-staging-and-job-interpretation.md
+  type: doc
+  doc_version: 0.1.0
+  status: active
+  last_updated: 2026-06-28
+  sha256: 3bdca73c8c01464de1b729b9ae854895284bfb9f8444cd5222dd11e451e00d9f

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -1,13 +1,13 @@
 ---
 version: 1.0.0
-last_updated: 2026-06-18
+last_updated: 2026-06-28
 ---
 
 # Lumina Framework Roadmap
 
 **Version:** 1.0.0
 **Status:** Active
-**Last updated:** 2026-06-18
+**Last updated:** 2026-06-28
 
 ---
 
@@ -32,6 +32,9 @@ under `docs/roadmap/slices/` and delivered as a focused PR.
 | [04](slices/04-system-pack-authority-gate.md) | System Pack Authority Gate | Active |
 | [05](slices/05-system-pack-sole-coding-agent-ingress.md) | System Pack as Sole Coding Agent Ingress | Active |
 | [06](slices/06-coding-agent-model-pack-architecture-v2.md) | Coding Agent Model Pack Architecture V2 | Active |
+| [07](slices/07-coding-agent-pack-skeleton.md) | Coding Agent Pack Skeleton | Delivered |
+| [08](slices/08-job-intake-micro-context.md) | Job Intake and Micro-Context Injector | Delivered |
+| [09](slices/09-context-staging-and-job-interpretation.md) | Context Staging and Job Interpretation | Planned |
 
 ---
 

--- a/docs/roadmap/slices/07-coding-agent-pack-skeleton.md
+++ b/docs/roadmap/slices/07-coding-agent-pack-skeleton.md
@@ -6,9 +6,9 @@ last_updated: 2026-06-28
 # Slice 7: Coding Agent Pack Skeleton
 
 **Version:** 1.0.0
-**Status:** Active
+**Status:** Delivered
 **Last updated:** 2026-06-28
-**PR:** Adds the initial `model-packs/coding-agent/` skeleton.
+**PRs:** #62 (skeleton), #63 (manifest fix)
 
 ---
 

--- a/docs/roadmap/slices/08-job-intake-micro-context.md
+++ b/docs/roadmap/slices/08-job-intake-micro-context.md
@@ -1,0 +1,139 @@
+---
+version: 1.0.0
+last_updated: 2026-06-28
+---
+
+# Slice 8: Job Intake and Micro-Context Injector
+
+**Version:** 1.0.0
+**Status:** Delivered
+**Last updated:** 2026-06-28
+**PR:** #64
+
+---
+
+## Purpose
+
+Provide lightweight, deterministic job-payload validation and a micro-context
+builder so the coding-agent's pre-interpreter can produce authoritative routing
+signals before any SLM call.
+
+The coding-agent pack must classify incoming jobs and select a routing tier
+(`critical`, `ok`, `minor`) without touching live models, credentials, or
+network calls. This slice gives the pre-interpreter the vocabulary it needs.
+
+---
+
+## Scope
+
+- `model-packs/coding-agent/domain-lib/job_intake.py`:
+  `ValidationResult` class, `validate_job(payload) -> ValidationResult`
+- `model-packs/coding-agent/domain-lib/micro_context.py`:
+  `build_micro_context(normalized_job, extras) -> dict`
+- `model-packs/coding-agent/controllers/nlp_pre_interpreter.py` (updated):
+  extract JSON job from input text; call `validate_job` + `build_micro_context`;
+  expose `job_validation` and `micro_context` keys in the `pre_interpret()` output
+- `model-packs/coding-agent/controllers/runtime_adapters.py` (updated):
+  `domain_step()` reads `evidence["micro_context"]` to prefer `scope_valid` and
+  `tier` for routing decisions over raw evidence flags
+- `tests/test_coding_agent_job_intake.py`: 3 focused tests
+
+---
+
+## Out of Scope
+
+- Live model calls, network calls, credential use
+- Changing `src/lumina/` core code
+- Forge or deployment automation
+- Hermes prototype services (deferred to Slice 9)
+
+---
+
+## Required Changes
+
+| File | Change |
+|------|--------|
+| `domain-lib/job_intake.py` | CREATE — `ValidationResult`, `validate_job()` |
+| `domain-lib/micro_context.py` | CREATE — `build_micro_context()` |
+| `controllers/nlp_pre_interpreter.py` | UPDATE — add JSON extraction, validation, micro-context building |
+| `controllers/runtime_adapters.py` | UPDATE — `domain_step()` reads `micro_context` dict |
+| `tests/test_coding_agent_job_intake.py` | CREATE — 3 tests |
+| `docs/MANIFEST.yaml` | UPDATE — add pending entries, regen |
+
+---
+
+## New / Changed Contracts
+
+| Symbol | Location | Description |
+|--------|----------|-------------|
+| `ValidationResult` | `domain-lib/job_intake.py` | `.valid: bool`, `.errors: list[str]`, `.normalized: dict` |
+| `validate_job(payload)` | `domain-lib/job_intake.py` | Title required and non-empty; description ≥ 10 chars; priority ∈ `{low, normal, high}` (optional) |
+| `build_micro_context(norm, extras)` | `domain-lib/micro_context.py` | Returns dict: `job_id`, `tier`, `scope_valid`, `files`, `created_at`, `extras` |
+| `pre_interpret()` output | `controllers/nlp_pre_interpreter.py` | Adds `job_validation: dict\|None` and `micro_context: dict\|None` keys |
+| `domain_step()` routing | `controllers/runtime_adapters.py` | Reads `evidence["micro_context"]` when present; prefers `scope_valid` and `tier` over raw flags |
+
+### Priority → Tier Mapping
+
+| Priority | Tier |
+|----------|------|
+| `high` | `critical` |
+| `normal` | `ok` |
+| `low` | `minor` |
+
+---
+
+## Files Touched
+
+```
+model-packs/coding-agent/
+  domain-lib/
+    job_intake.py          ← new
+    micro_context.py       ← new
+  controllers/
+    nlp_pre_interpreter.py ← updated
+    runtime_adapters.py    ← updated
+tests/
+  test_coding_agent_job_intake.py ← new
+docs/
+  MANIFEST.yaml            ← updated (regen)
+```
+
+---
+
+## Acceptance Criteria
+
+- `validate_job({})` returns `valid=False` with at least one error in `.errors`.
+- `validate_job({"title": "Add README", "description": "Add a README explaining usage.", "priority": "normal"})` returns `valid=True` and `.normalized["priority"] == "normal"`.
+- `build_micro_context(normalized)` maps `priority="high"` → `tier="critical"`, `"normal"` → `"ok"`, `"low"` → `"minor"`.
+- `pre_interpret(text_containing_json_job)` returns a dict where `micro_context` is not `None`.
+- `domain_step()` uses `micro_context["scope_valid"]` when `evidence["micro_context"]` is present, in preference to the raw `job_scope_valid` evidence flag.
+
+---
+
+## Tests
+
+**File:** `tests/test_coding_agent_job_intake.py`
+
+| Test | Description |
+|------|-------------|
+| `test_validate_job_ok` | Valid payload passes; normalized priority returned correctly |
+| `test_validate_job_missing_fields` | Empty title and short description both produce errors |
+| `test_pre_interpret_extracts_micro_context` | JSON job embedded in input text → `micro_context["tier"] == "critical"` for high priority |
+
+All tests: no network, no live model, no credentials.
+
+---
+
+## Ledger / Governance Impact
+
+None. This slice adds deterministic domain-lib helpers inside the coding-agent pack
+boundary. It does not change authority gate logic, domain registry, or core engine
+invariants.
+
+---
+
+## Follow-Up Slices
+
+**Slice 9:** Context Staging and Job Interpretation — abstract Hermes prototype patterns
+(`context_staging.py`, `job_interpreter.py`, `change_request.py`) into neutral,
+authority-air-gapped coding-agent pack contracts.

--- a/docs/roadmap/slices/09-context-staging-and-job-interpretation.md
+++ b/docs/roadmap/slices/09-context-staging-and-job-interpretation.md
@@ -1,0 +1,190 @@
+---
+version: 0.1.0
+last_updated: 2026-06-28
+---
+
+# Slice 9: Context Staging and Job Interpretation
+
+**Version:** 0.1.0
+**Status:** Planned
+**Last updated:** 2026-06-28
+
+---
+
+## Purpose
+
+Abstract proven patterns from the Hermes operational prototype into neutral,
+authority-air-gapped coding-agent pack contracts. Three new modules provide:
+
+1. **Context staging** — deterministic, budget-aware selection of relevant file
+   chunks to include in a model prompt window without requiring embedding models.
+2. **Job interpretation** — classify short affirmatives, extract and validate
+   tool-call JSON, normalize tool names against an explicit allowlist.
+3. **Change-request contracts** — forge-neutral validation of branch names,
+   allowed paths, and change-request payloads; no GitHub-specific coupling.
+
+The `hermesport/` directory remains an ignored, operator-local prototype.
+No hermesport code is copied verbatim; only the contracts are abstracted.
+
+---
+
+## Scope
+
+### A. `model-packs/coding-agent/domain-lib/context_staging.py`
+
+| Function | Signature | Notes |
+|----------|-----------|-------|
+| `rough_tokens` | `(text: str) -> int` | Word-count heuristic; no external tokenizer |
+| `clean_text` | `(text: str) -> str` | Strip null bytes, collapse excess whitespace |
+| `split_words` | `(text, chunk_words=220, overlap_words=40) -> list[str]` | Sliding window chunker |
+| `stage_context` | `(chunks, query, budget_tokens=4500, top_k=6, max_per_path=2) -> dict` | Lexical scorer; returns `{selected, summary, provenance, recall_hints}` |
+
+**`stage_context` return shape:**
+```python
+{
+    "selected": [{"text": str, "path": str, "score": float}, ...],
+    "summary": str,            # brief human-readable provenance summary
+    "provenance": {
+        "budget_tokens": int,
+        "selected_count": int,
+        "query": str,
+    },
+    "recall_hints": [str, ...] # broad/low-confidence terms from query
+}
+```
+
+### B. `model-packs/coding-agent/controllers/job_interpreter.py`
+
+| Function | Signature | Notes |
+|----------|-----------|-------|
+| `classify_job_mode` | `(text: str) -> str` | Returns `"execution"`, `"review"`, `"query"`, or `"unknown"` |
+| `extract_tool_json_value` | `(text: str) -> object \| None` | Extracts first JSON object from fenced or inline text |
+| `normalize_tool_call` | `(obj: dict, allowed_tools: dict \| None) -> dict` | Validates tool name; raises `ValueError` on unknown tool if allowlist provided |
+| `normalize_tool_calls` | `(text: str, allowed_tools: dict \| None) -> list[dict]` | Combines extraction + normalization; returns `[]` on parse failure |
+
+**`classify_job_mode` rules:**
+- Short affirmatives (`"yes"`, `"ok"`, `"go"`, `"sure"`, `"proceed"`, `"do it"`) → `"execution"`
+- Contains `"review"`, `"check"`, `"inspect"`, `"read"` → `"review"`
+- Contains `"what"`, `"how"`, `"why"`, `"explain"`, `"list"` → `"query"`
+- Otherwise → `"unknown"`
+
+### C. `model-packs/coding-agent/domain-lib/change_request.py`
+
+| Function | Signature | Notes |
+|----------|-----------|-------|
+| `validate_allowed_path` | `(path: str, allowed_prefixes: list[str]) -> bool` | Rejects absolute paths and paths outside allowed prefixes |
+| `validate_change_branch` | `(branch: str) -> bool` | Rejects `..`, `@{`, leading/trailing `/`, whitespace, empty strings |
+| `normalize_change_request_request` | `(payload: dict) -> dict` | Returns canonical shape; raises `ValueError` on missing required fields |
+
+**`normalize_change_request_request` output shape:**
+```python
+{
+    "title": str,
+    "description": str,
+    "branch": str,
+    "files_changed": list[str],
+    "author": str | None,
+    "metadata": dict,
+}
+```
+
+---
+
+## Out of Scope
+
+- FastAPI, SentenceTransformer, numpy, SQLite, Docker, vLLM
+- GitHub CLI (`gh pr create`), subprocess git automation
+- Live model calls, network calls, credential handling
+- Copying hermesport/ code verbatim into the pack
+- Changing `src/lumina/` core code
+- Modifying existing domain-physics invariants
+
+---
+
+## Required Changes
+
+| Action | Path |
+|--------|------|
+| CREATE | `model-packs/coding-agent/domain-lib/context_staging.py` |
+| CREATE | `model-packs/coding-agent/controllers/job_interpreter.py` |
+| CREATE | `model-packs/coding-agent/domain-lib/change_request.py` |
+| CREATE | `tests/test_coding_agent_hermes_abstractions.py` |
+| UPDATE | `model-packs/coding-agent/CHANGELOG.md` (add 0.3.0) |
+| UPDATE | `docs/roadmap/README.md` (Slice 9 status → Delivered) |
+| UPDATE | `docs/MANIFEST.yaml` + regen |
+
+---
+
+## Files Likely Touched
+
+```
+model-packs/coding-agent/
+  domain-lib/
+    context_staging.py     ← new
+    change_request.py      ← new
+  controllers/
+    job_interpreter.py     ← new
+tests/
+  test_coding_agent_hermes_abstractions.py ← new
+docs/
+  MANIFEST.yaml            ← updated (regen)
+  roadmap/README.md        ← status update
+  roadmap/slices/09-...md  ← this file, status → Delivered
+model-packs/coding-agent/
+  CHANGELOG.md             ← 0.3.0 entry
+```
+
+---
+
+## Acceptance Criteria
+
+**Context staging:**
+- `rough_tokens("hello world")` returns `2`
+- `clean_text("foo\x00bar")` returns `"foobar"` (null stripped)
+- `split_words(long_text, chunk_words=5, overlap_words=1)` produces overlapping chunks where consecutive chunks share the last word of the previous chunk
+- `stage_context(chunks, query, budget_tokens=50, top_k=6, max_per_path=1)` returns no more than one chunk per unique path
+- `stage_context` does not exceed `budget_tokens` in total selected token count
+
+**Job interpretation:**
+- `classify_job_mode("yes")` → `"execution"`
+- `classify_job_mode("ok go")` → `"execution"`
+- `classify_job_mode("review this carefully")` → `"review"`
+- `classify_job_mode("what does this do?")` → `"query"`
+- Fenced JSON ` ```json\n{"tool": "read_file"}\n``` ` extracted correctly by `extract_tool_json_value`
+- Unknown tool name in `normalize_tool_call` with a non-`None` allowlist raises `ValueError`
+
+**Change-request:**
+- `validate_change_branch("feat/my-topic")` → `True`
+- `validate_change_branch("../bad")` → `False`
+- `validate_change_branch("bad@{upstream}")` → `False`
+- `validate_allowed_path("src/lumina/foo.py", ["src/lumina/"])` → `True`
+- `validate_allowed_path("/etc/passwd", ["src/"])` → `False`
+- `validate_allowed_path("../../escape.py", ["src/"])` → `False`
+
+---
+
+## Tests
+
+**File:** `tests/test_coding_agent_hermes_abstractions.py`
+
+Grouped into three classes or sections:
+1. `TestContextStaging` — covers `rough_tokens`, `clean_text`, `split_words`, `stage_context` budget and max_per_path constraints
+2. `TestJobInterpreter` — covers all four `classify_job_mode` branches, JSON extraction from fenced and inline text, unknown-tool rejection
+3. `TestChangeRequest` — covers branch validation (valid and invalid patterns), path validation, `normalize_change_request_request` happy path and missing-field error
+
+All tests: no network, no live model, no subprocess calls, no credentials.
+
+---
+
+## Ledger / Governance Impact
+
+None. New domain-lib helpers operate inside the coding-agent pack boundary.
+No authority gate logic, domain registry, or core engine invariants are changed.
+
+---
+
+## Follow-Up Slices
+
+**Slice 10:** Tool-Adapter Policy Enforcement — introduce deny-by-default
+`tool_call_policies` blocks in `domain-physics.json` and validate that
+`normalize_tool_call` respects the policy before routing any tool request.

--- a/model-packs/coding-agent/CHANGELOG.md
+++ b/model-packs/coding-agent/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Coding Agent Pack Changelog
 
+## 0.2.0 — 2026-06-28
+
+- Added `domain-lib/job_intake.py`: `ValidationResult` class and `validate_job()` — lightweight deterministic payload validation (title required, description ≥ 10 chars, priority enum check).
+- Added `domain-lib/micro_context.py`: `build_micro_context()` — maps job priority to routing tier and builds a micro-context dict for downstream routing.
+- Updated `controllers/nlp_pre_interpreter.py`: wires `validate_job` + `build_micro_context` on JSON payloads found in input; exposes `job_validation` and `micro_context` output keys.
+- Updated `controllers/runtime_adapters.py`: `domain_step()` reads `evidence["micro_context"]` to prefer `scope_valid` and `tier` for routing decisions.
+- Added `tests/test_coding_agent_job_intake.py`: 3 focused tests covering validator, micro-context builder, and pre-interpreter extraction.
+- `docs/MANIFEST.yaml` regenerated; 296 SHA-256 entries OK.
+
 ## 0.1.0 — 2026-06-28
 
 - Added initial Slice 7 skeleton for the coding-agent model pack.


### PR DESCRIPTION
Updates planning documents to reflect current coding-agent model pack development state:\n\n- Marks Slice 7 (Pack Skeleton) as **Delivered** (PRs #62/#63)\n- Adds formal Slice 8 doc: Job Intake and Micro-Context Injector (**Delivered**, PR #64)\n- Adds Slice 9 design doc: Context Staging and Job Interpretation (**Planned** — `context_staging.py`, `job_interpreter.py`, `change_request.py`)\n- Updates roadmap index table (`docs/roadmap/README.md`) with all three slices\n- Updates `model-packs/coding-agent/CHANGELOG.md` with `0.2.0` entry\n- `docs/MANIFEST.yaml` regenerated (298 OK, 0 mismatch)