### PR TITLE
chore(dev): add binary test deps and ignore local logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,17 @@ tests/artifacts/phase7-full-suite-results.txt
 src/web/package-lock.json
 
 
+install_log.txt
+.gitignore
+pip_reinstall_log.txt
+.gitignore
+pytest_full_log.txt
+.gitignore
+pytest_log.txt
+pytest_run.txt
+pytest_full_log_utf8.txt
+install_editable_log.txt
+.gitignore
+.gitignore
+pytest_log2.txt
+install_providers_log.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,7 @@ aiosqlite>=0.20.0
 httpx>=0.27.0
 bcrypt>=4.0.0
 argon2-cffi>=23.1.0
+
+# Add low-level binary/runtime deps required by test collection
+pydantic-core>=2.46.4
+rpds-py>=0.26.0


### PR DESCRIPTION
Add pydantic-core and rpds-py to requirements-dev.txt and ignore local install/test logs in .gitignore. Helps local test collection on Windows/3.12.