### PR TITLE
feat(coding-agent): Slice 14 DAG-correct compute orchestration

### DIFF
--- a/docs/MANIFEST.yaml
+++ b/docs/MANIFEST.yaml
@@ -29,6 +29,13 @@ artifacts:
   status: planned
   last_updated: 2026-06-29
   sha256: 8a5536032d1c2e8d34951bcf25b5a08a3c07837c927a22514784fba56039e294
+- path: docs/roadmap/slices/14-dag-correct-compute-orchestration.md
+  type: doc
+  section: 0
+  doc_version: 1.0.0
+  status: planned
+  last_updated: 2026-06-29
+  sha256: 30b5abd06617db949bebb5478f4b28d2c12c5f65aa7e91191689ab5259bc4a45
 - path: docs/1-commands/README.md
   type: doc
   section: 1

--- a/docs/roadmap/slices/14-dag-correct-compute-orchestration.md
+++ b/docs/roadmap/slices/14-dag-correct-compute-orchestration.md
@@ -1,0 +1,45 @@
+---
+title: "Slice 14 — DAG-Correct Compute Orchestration"
+pack: model-packs/coding-agent/pack.yaml
+version: 0.9.0
+last_updated: 2026-06-29
+sha256: pending
+---
+
+Slice 14 makes DAG correctness the efficiency gate for the coding-agent compute tiers.
+Terminology is supporting context; the primary goal is that work can be planned,
+sliced, and executed without dependency drift or wasted model calls.
+
+## Purpose
+
+The coding-agent stack relies on DAG quality for efficient execution:
+
+- Tier 1 owns the global DAG and system-state references.
+- Tier 2 derives dependency-preserving slices and micro-DAG handoffs.
+- Tier 3 executes only ready work whose upstream dependencies are satisfied.
+
+## DAG Invariants
+
+1. Node IDs are unique within a DAG.
+2. Dependencies point to existing nodes.
+3. DAGs are acyclic.
+4. Topological ordering is deterministic for equal-ready nodes.
+5. Micro-DAG nodes and task slices preserve lineage to global nodes.
+6. Task slices preserve dependency context, model class, and tool constraints.
+7. Invalid DAGs are rejected before slicing or execution.
+
+## Implementation Scope
+
+- Add a deterministic architect plan contract for Tier 1 global plans.
+- Strengthen DAG validation with stable ordering, ready-node calculation, and lineage checks.
+- Preserve dependency and parent lineage in generated task slices.
+- Wire Tier 1 dispatch to return global plan evidence and reject invalid DAGs.
+- Add focused DAG correctness tests for contracts, validation, slicing, and dispatch.
+
+## Acceptance Criteria
+
+- Targeted DAG correctness tests pass.
+- Tier 1 dispatch returns global plan evidence with system-state references.
+- Tier 2 dispatch rejects invalid DAGs before generating task slices.
+- Generated slices preserve dependency context and model routing metadata.
+- This document is tracked in `docs/MANIFEST.yaml` and hashes are regenerated with `scripts/manifest-regenerate.ps1`.

--- a/model-packs/coding-agent/controllers/tier_dispatcher.py
+++ b/model-packs/coding-agent/controllers/tier_dispatcher.py
@@ -47,6 +47,67 @@ def _resolve_tool_registry() -> Dict[str, Any]:
 def dispatch_to_tier(tier: int, task_slice: Dict[str, Any]) -> Dict[str, Any]:
     registry = _resolve_tool_registry()
 
+    # Tier-1: build a global architect plan and validate DAG invariants before handoff.
+    if tier == 1:
+        try:
+            job = task_slice if isinstance(task_slice, dict) else {}
+            try:
+                from ..domain_lib import tier1_architect, tier2_decomposer, dag_validator
+            except Exception:
+                import importlib.util, pathlib, sys
+
+                base = pathlib.Path(__file__).parent
+
+                a_path = base.parent / "domain-lib" / "tier1_architect.py"
+                spec = importlib.util.spec_from_file_location("coding_agent_tier1_architect", str(a_path))
+                tier1_architect = importlib.util.module_from_spec(spec)
+                sys.modules["coding_agent_tier1_architect"] = tier1_architect
+                spec.loader.exec_module(tier1_architect)
+
+                dec_path = base.parent / "domain-lib" / "tier2_decomposer.py"
+                spec = importlib.util.spec_from_file_location("coding_agent_tier2_decomposer", str(dec_path))
+                tier2_decomposer = importlib.util.module_from_spec(spec)
+                sys.modules["coding_agent_tier2_decomposer"] = tier2_decomposer
+                spec.loader.exec_module(tier2_decomposer)
+
+                val_path = base.parent / "domain-lib" / "dag_validator.py"
+                spec = importlib.util.spec_from_file_location("coding_agent_dag_validator", str(val_path))
+                dag_validator = importlib.util.module_from_spec(spec)
+                sys.modules["coding_agent_dag_validator"] = dag_validator
+                spec.loader.exec_module(dag_validator)
+
+            architect_plan = tier1_architect.architect_global_plan(job)
+            dag = architect_plan.global_dag
+            validation = list(architect_plan.validation_errors or [])
+            if validation:
+                return {
+                    "tier": 1,
+                    "dispatched": False,
+                    "reason": "invalid_global_dag",
+                    "architect_plan": architect_plan.to_dict(),
+                    "validation": validation,
+                }
+
+            _dag, node_tools = tier2_decomposer.decompose_job(job)
+            model_class_map = tier1_architect.build_model_class_map(dag)
+            allowed = job.get("allowed_tools") or [
+                "adapter/ca/read-file/v1",
+                "adapter/ca/write-file/v1",
+                "adapter/ca/run-tests/v1",
+                "adapter/ca/stage-patch/v1",
+            ]
+            slices = tier2_decomposer.assign_task_slices(dag, node_tools, allowed, model_class_map=model_class_map)
+            lineage_errors = dag_validator.validate_task_slice_lineage(dag, slices)
+            return {
+                "tier": 1,
+                "dispatched": not lineage_errors,
+                "architect_plan": architect_plan.to_dict(),
+                "task_slices": [s.to_dict() for s in slices],
+                "validation": lineage_errors,
+            }
+        except Exception as exc:
+            return {"tier": 1, "dispatched": False, "reason": f"architect_failed: {exc}"}
+
     # Tier-2: perform decomposition/planning and return a PlanDAG + TaskSlices
     if tier == 2:
         try:
@@ -73,6 +134,14 @@ def dispatch_to_tier(tier: int, task_slice: Dict[str, Any]) -> Dict[str, Any]:
 
             dag, node_tools = tier2_decomposer.decompose_job(job)
             errors = dag_validator.validate_dag(dag)
+            if errors:
+                return {
+                    "tier": 2,
+                    "dispatched": False,
+                    "reason": "invalid_dag",
+                    "plan": dag.to_dict(),
+                    "validation": errors,
+                }
             # Tier-1 architect: classify nodes and build a model_class map
             try:
                 from ..domain_lib import tier1_architect

--- a/model-packs/coding-agent/domain-lib/dag_validator.py
+++ b/model-packs/coding-agent/domain-lib/dag_validator.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List
+from typing import Dict, List, Set
 
 # Robust imports: allow module to be loaded as a standalone file during tests
 try:
@@ -36,12 +36,85 @@ def validate_dag(dag: tier_contracts.PlanDAG) -> List[str]:
             if dep not in node_set:
                 errors.append(f"dangling_depends_on: {n.node_id} -> {dep}")
 
-    # Simple cycle check via attempt to topologically sort
     try:
-        from . import tier2_decomposer
-
-        tier2_decomposer.topological_sort(dag)
+        stable_topological_sort(dag)
     except Exception as exc:
         errors.append(f"cycle_or_sort_error: {exc}")
 
+    return errors
+
+
+def stable_topological_sort(dag: tier_contracts.PlanDAG) -> List[tier_contracts.PlanNode]:
+    """Return a deterministic topological order for a valid DAG.
+
+    Ready nodes are ordered by node_id so equal-priority plans produce stable
+    output across Python versions and environments.
+    """
+    nodes = {n.node_id: n for n in dag.nodes}
+    indeg: Dict[str, int] = {nid: 0 for nid in nodes}
+    adj: Dict[str, List[str]] = {nid: [] for nid in nodes}
+
+    for n in dag.nodes:
+        for dep in n.depends_on or []:
+            if dep in nodes:
+                indeg[n.node_id] += 1
+                adj[dep].append(n.node_id)
+
+    ready = sorted([nid for nid, degree in indeg.items() if degree == 0])
+    ordered: List[tier_contracts.PlanNode] = []
+    while ready:
+        cur = ready.pop(0)
+        ordered.append(nodes[cur])
+        for child in sorted(adj.get(cur, [])):
+            indeg[child] -= 1
+            if indeg[child] == 0:
+                ready.append(child)
+        ready.sort()
+
+    if len(ordered) != len(nodes):
+        raise ValueError("cycle detected in PlanDAG")
+    return ordered
+
+
+def ready_node_ids(dag: tier_contracts.PlanDAG, completed_node_ids: Set[str] | List[str]) -> List[str]:
+    """Return executable node ids whose dependencies are all completed."""
+    completed = set(completed_node_ids or [])
+    ordered = stable_topological_sort(dag)
+    ready: List[str] = []
+    for n in ordered:
+        if n.node_id in completed:
+            continue
+        if all(dep in completed for dep in (n.depends_on or [])):
+            ready.append(n.node_id)
+    return ready
+
+
+def validate_micro_dag_lineage(
+    global_dag: tier_contracts.PlanDAG,
+    micro_dag: tier_contracts.PlanDAG,
+) -> List[str]:
+    """Validate that every micro-DAG node traces to an existing global node."""
+    errors: List[str] = []
+    global_ids = {n.node_id for n in global_dag.nodes}
+    for n in micro_dag.nodes:
+        parent = getattr(n, "parent_node_id", "") or n.node_id
+        if parent not in global_ids:
+            errors.append(f"missing_global_parent: {n.node_id} -> {parent}")
+    return errors
+
+
+def validate_task_slice_lineage(
+    dag: tier_contracts.PlanDAG,
+    slices: List[tier_contracts.TaskSlice],
+) -> List[str]:
+    """Validate that TaskSlices preserve a valid node/global parent reference."""
+    errors: List[str] = []
+    node_ids = {n.node_id for n in dag.nodes}
+    for ts in slices:
+        parent = getattr(ts, "parent_node_id", "") or ts.node_id
+        if parent not in node_ids:
+            errors.append(f"slice_missing_parent: {ts.slice_id} -> {parent}")
+        for dep in getattr(ts, "depends_on", []) or []:
+            if dep not in node_ids:
+                errors.append(f"slice_dangling_depends_on: {ts.slice_id} -> {dep}")
     return errors

--- a/model-packs/coding-agent/domain-lib/tier1_architect.py
+++ b/model-packs/coding-agent/domain-lib/tier1_architect.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from typing import Dict
+from datetime import datetime
+from typing import Any, Dict, List
 
 # Robust imports: allow module to be loaded as a standalone file during tests
 try:
-    from .tier_contracts import PlanDAG, PlanNode
+    from .tier_contracts import ArchitectPlan, PlanDAG, PlanNode
 except Exception:
     import importlib.util
     import pathlib
@@ -19,6 +20,7 @@ except Exception:
 
     PlanDAG = tier_contracts.PlanDAG
     PlanNode = tier_contracts.PlanNode
+    ArchitectPlan = tier_contracts.ArchitectPlan
 
 
 def _is_documentation_node(node: PlanNode) -> bool:
@@ -65,3 +67,47 @@ def build_model_class_map(dag: PlanDAG) -> Dict[str, str]:
     for n in dag.nodes:
         mapping[n.node_id] = "slm" if (n.action_type == "document") else "llm"
     return mapping
+
+
+def architect_global_plan(job: Dict[str, Any], system_state_refs: List[str] | None = None) -> ArchitectPlan:
+    """Build a deterministic global architect plan for a coding-agent job.
+
+    This is intentionally model-free: Tier 1 establishes a validated global DAG
+    and tier assignments so downstream tiers can slice and execute only valid,
+    dependency-aware work.
+    """
+    try:
+        from . import tier2_decomposer, dag_validator
+    except Exception:
+        import importlib.util
+        import pathlib
+        import sys
+
+        base = pathlib.Path(__file__).parent
+
+        dec_path = base / "tier2_decomposer.py"
+        spec = importlib.util.spec_from_file_location("coding_agent_tier2_decomposer", str(dec_path))
+        tier2_decomposer = importlib.util.module_from_spec(spec)
+        sys.modules["coding_agent_tier2_decomposer"] = tier2_decomposer
+        spec.loader.exec_module(tier2_decomposer)
+
+        val_path = base / "dag_validator.py"
+        spec = importlib.util.spec_from_file_location("coding_agent_dag_validator", str(val_path))
+        dag_validator = importlib.util.module_from_spec(spec)
+        sys.modules["coding_agent_dag_validator"] = dag_validator
+        spec.loader.exec_module(dag_validator)
+
+    dag, _node_tools = tier2_decomposer.decompose_job(job or {})
+    dag = classify_nodes(dag)
+    validation_errors = dag_validator.validate_dag(dag)
+    root_job_id = str((job or {}).get("job_id") or "root")
+    tier_assignments = {n.node_id: int(getattr(n, "tier_hint", 2) or 2) for n in dag.nodes}
+    return ArchitectPlan(
+        plan_id=f"architect-plan-{root_job_id}",
+        root_job_id=root_job_id,
+        global_dag=dag,
+        system_state_refs=list(system_state_refs or (job or {}).get("system_state_refs") or []),
+        tier_assignments=tier_assignments,
+        validation_errors=validation_errors,
+        created_at=datetime.utcnow().isoformat() + "Z",
+    )

--- a/model-packs/coding-agent/domain-lib/tier2_decomposer.py
+++ b/model-packs/coding-agent/domain-lib/tier2_decomposer.py
@@ -20,8 +20,12 @@ except Exception:
     sys.modules["coding_agent_tier_contracts"] = tier_contracts
     spec.loader.exec_module(tier_contracts)
 
+PlanDAG = tier_contracts.PlanDAG
+PlanNode = tier_contracts.PlanNode
+TaskSlice = tier_contracts.TaskSlice
 
-def decompose_job(job: Dict[str, Any]) -> Tuple[tier_contracts.PlanDAG, Dict[str, List[str]]]:
+
+def decompose_job(job: Dict[str, Any]) -> Tuple[PlanDAG, Dict[str, List[str]]]:
     """Produce a PlanDAG and a mapping of node_id -> allowed_tools.
 
     Accepts either a dict-shaped job or a CodingAgentJob-like object with
@@ -32,7 +36,7 @@ def decompose_job(job: Dict[str, Any]) -> Tuple[tier_contracts.PlanDAG, Dict[str
     # Guard: explicit error when task_graph present but malformed
     if task_graph is not None and not isinstance(task_graph, (list, tuple)):
         raise TypeError("task_graph must be a list of task nodes")
-    nodes: List[tier_contracts.PlanNode] = []
+    nodes: List[PlanNode] = []
     node_tools: Dict[str, List[str]] = {}
 
     if not task_graph:
@@ -58,7 +62,7 @@ def decompose_job(job: Dict[str, Any]) -> Tuple[tier_contracts.PlanDAG, Dict[str
     return dag, node_tools
 
 
-def topological_sort(dag: tier_contracts.PlanDAG) -> List[tier_contracts.PlanNode]:
+def topological_sort(dag: PlanDAG) -> List[PlanNode]:
     """Return PlanNodes in topologically-sorted order. Raises ValueError on cycle."""
     nodes = {n.node_id: n for n in dag.nodes}
     indeg: Dict[str, int] = {nid: 0 for nid in nodes}
@@ -71,7 +75,7 @@ def topological_sort(dag: tier_contracts.PlanDAG) -> List[tier_contracts.PlanNod
                 adj[dep].append(n.node_id)
 
     queue = [nid for nid, d in indeg.items() if d == 0]
-    order: List[tier_contracts.PlanNode] = []
+    order: List[PlanNode] = []
 
     while queue:
         cur = queue.pop(0)
@@ -87,7 +91,7 @@ def topological_sort(dag: tier_contracts.PlanDAG) -> List[tier_contracts.PlanNod
     return order
 
 
-def _estimate_tokens_for_node(node: tier_contracts.PlanNode) -> int:
+def _estimate_tokens_for_node(node: PlanNode) -> int:
     """Token estimate improved with length, priority, tool-costs, and dependency awareness.
 
     Parameters are intentionally deterministic so tests remain stable. The
@@ -137,8 +141,8 @@ def _estimate_tokens_for_node(node: tier_contracts.PlanNode) -> int:
 
 
 def group_nodes_into_slices(
-    dag: tier_contracts.PlanDAG, node_tools: Dict[str, List[str]], max_tokens_per_slice: int = 1024
-) -> List[List[tier_contracts.PlanNode]]:
+    dag: PlanDAG, node_tools: Dict[str, List[str]], max_tokens_per_slice: int = 1024
+) -> List[List[PlanNode]]:
     """Group topologically-ordered PlanNodes into buckets not exceeding token budget.
 
     Returns list of node lists representing each slice's assignment.
@@ -150,8 +154,8 @@ def group_nodes_into_slices(
         # attach node_tools map and dependents map for richer estimates
         setattr(n, "_node_tools", node_tools)
         setattr(n, "_dependents_map", dependents_map)
-    groups: List[List[tier_contracts.PlanNode]] = []
-    cur: List[tier_contracts.PlanNode] = []
+    groups: List[List[PlanNode]] = []
+    cur: List[PlanNode] = []
     cur_cost = 0
 
     for n in ordered:
@@ -176,7 +180,7 @@ def group_nodes_into_slices(
     return groups
 
 
-def _count_dependents(dag: tier_contracts.PlanDAG) -> Dict[str, int]:
+def _count_dependents(dag: PlanDAG) -> Dict[str, int]:
     """Return a map node_id -> count of downstream dependents (transitive).
 
     This is a simple BFS per node; DAGs are expected to be small so O(N^2)
@@ -206,17 +210,17 @@ def _count_dependents(dag: tier_contracts.PlanDAG) -> Dict[str, int]:
 
 
 def assign_task_slices(
-    dag: tier_contracts.PlanDAG,
+    dag: PlanDAG,
     node_tools: Dict[str, List[str]],
     allowed_tools: List[str],
     max_tokens_per_slice: int | None = None,
     model_class_map: Dict[str, str] | None = None,
-) -> List[tier_contracts.TaskSlice]:
+) -> List[TaskSlice]:
     """Map PlanNodes to TaskSlices. If `max_tokens_per_slice` is set, group nodes.
 
     Filtering of allowed adapters is applied per-node and per-slice.
     """
-    slices: List[tier_contracts.TaskSlice] = []
+    slices: List[TaskSlice] = []
     allowed_set = set(allowed_tools or [])
 
     if max_tokens_per_slice:
@@ -251,6 +255,8 @@ def assign_task_slices(
                 context_budget_tokens=max_tokens_per_slice,
                 tier=3,
                 model_class=slice_model,
+                depends_on=sorted({dep for n in group for dep in (n.depends_on or []) if dep not in {g.node_id for g in group}}),
+                parent_node_id=getattr(group[0], "parent_node_id", "") or group[0].node_id,
             )
             slices.append(ts)
         return slices
@@ -267,6 +273,8 @@ def assign_task_slices(
             context_budget_tokens=1024,
             tier=3,
             model_class=(model_class_map.get(n.node_id) if model_class_map else "llm"),
+            depends_on=list(n.depends_on or []),
+            parent_node_id=getattr(n, "parent_node_id", "") or n.node_id,
         )
         slices.append(ts)
     return slices

--- a/model-packs/coding-agent/domain-lib/tier_contracts.py
+++ b/model-packs/coding-agent/domain-lib/tier_contracts.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass, asdict, field
 from typing import List, Dict, Any
 from datetime import datetime
 
@@ -15,6 +15,9 @@ class PlanNode:
     # Examples: "code", "document", "review". Defaults to "code" for
     # backward compatibility with existing nodes.
     action_type: str = "code"
+    # Optional lineage to a parent/global node when this node is derived into
+    # a micro-DAG. Empty means this node is already global/root-level.
+    parent_node_id: str = ""
 
 
 @dataclass
@@ -32,6 +35,40 @@ class PlanDAG:
 
 
 @dataclass
+class ArchitectPlan:
+    plan_id: str
+    root_job_id: str
+    global_dag: PlanDAG
+    system_state_refs: List[str] = field(default_factory=list)
+    tier_assignments: Dict[str, int] = field(default_factory=dict)
+    validation_errors: List[str] = field(default_factory=list)
+    created_at: str = field(default_factory=lambda: datetime.utcnow().isoformat() + "Z")
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "plan_id": self.plan_id,
+            "root_job_id": self.root_job_id,
+            "global_dag": self.global_dag.to_dict(),
+            "system_state_refs": list(self.system_state_refs or []),
+            "tier_assignments": dict(self.tier_assignments or {}),
+            "validation_errors": list(self.validation_errors or []),
+            "created_at": self.created_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ArchitectPlan":
+        return cls(
+            plan_id=str(data.get("plan_id", "")),
+            root_job_id=str(data.get("root_job_id", "")),
+            global_dag=PlanDAG.from_dict(data.get("global_dag") or {}),
+            system_state_refs=list(data.get("system_state_refs") or []),
+            tier_assignments={str(k): int(v) for k, v in dict(data.get("tier_assignments") or {}).items()},
+            validation_errors=list(data.get("validation_errors") or []),
+            created_at=data.get("created_at") or datetime.utcnow().isoformat() + "Z",
+        )
+
+
+@dataclass
 class TaskSlice:
     slice_id: str
     node_id: str
@@ -42,6 +79,8 @@ class TaskSlice:
     # Model class to execute this slice. Examples: "llm", "slm". Default
     # remains "llm" to preserve current behavior.
     model_class: str = "llm"
+    depends_on: List[str] = field(default_factory=list)
+    parent_node_id: str = ""
 
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)
@@ -56,4 +95,6 @@ class TaskSlice:
             context_budget_tokens=int(data.get("context_budget_tokens", 1024)),
             tier=int(data.get("tier", 3)),
             model_class=str(data.get("model_class", "llm")),
+            depends_on=list(data.get("depends_on") or []),
+            parent_node_id=str(data.get("parent_node_id", "")),
         )

--- a/tests/test_coding_agent_dag_correctness.py
+++ b/tests/test_coding_agent_dag_correctness.py
@@ -1,0 +1,158 @@
+import importlib.util
+import pathlib
+import sys
+
+base = pathlib.Path(__file__).parent.parent / "model-packs" / "coding-agent"
+domain = base / "domain-lib"
+controllers = base / "controllers"
+
+
+def _load(name: str, path: pathlib.Path):
+    spec = importlib.util.spec_from_file_location(name, str(path))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+dag_validator = _load("coding_agent_dag_validator_slice14", domain / "dag_validator.py")
+tier_contracts = dag_validator.tier_contracts
+tier1_architect = _load("coding_agent_tier1_architect_slice14", domain / "tier1_architect.py")
+tier2_decomposer = _load("coding_agent_tier2_decomposer_slice14", domain / "tier2_decomposer.py")
+tier_dispatcher = _load("coding_agent_tier_dispatcher_slice14", controllers / "tier_dispatcher.py")
+
+
+def _dag(nodes):
+    return tier_contracts.PlanDAG(nodes=nodes, created_at="now")
+
+
+def test_validate_dag_rejects_duplicate_ids():
+    dag = _dag([
+        tier_contracts.PlanNode("a", "first", []),
+        tier_contracts.PlanNode("a", "second", []),
+    ])
+
+    errors = dag_validator.validate_dag(dag)
+
+    assert "duplicate_node_id: a" in errors
+
+
+def test_validate_dag_rejects_dangling_dependency():
+    dag = _dag([tier_contracts.PlanNode("a", "needs missing", ["missing"])])
+
+    errors = dag_validator.validate_dag(dag)
+
+    assert "dangling_depends_on: a -> missing" in errors
+
+
+def test_validate_dag_rejects_cycle():
+    dag = _dag([
+        tier_contracts.PlanNode("a", "first", ["b"]),
+        tier_contracts.PlanNode("b", "second", ["a"]),
+    ])
+
+    errors = dag_validator.validate_dag(dag)
+
+    assert any(e.startswith("cycle_or_sort_error:") for e in errors)
+
+
+def test_stable_topological_sort_orders_equal_ready_nodes_by_id():
+    dag = _dag([
+        tier_contracts.PlanNode("b", "second ready", []),
+        tier_contracts.PlanNode("a", "first ready", []),
+        tier_contracts.PlanNode("c", "after both", ["a", "b"]),
+    ])
+
+    ordered = [n.node_id for n in dag_validator.stable_topological_sort(dag)]
+
+    assert ordered == ["a", "b", "c"]
+
+
+def test_ready_node_ids_excludes_incomplete_dependencies():
+    dag = _dag([
+        tier_contracts.PlanNode("a", "root", []),
+        tier_contracts.PlanNode("b", "child", ["a"]),
+        tier_contracts.PlanNode("c", "other child", ["a"]),
+        tier_contracts.PlanNode("d", "blocked", ["b", "c"]),
+    ])
+
+    assert dag_validator.ready_node_ids(dag, []) == ["a"]
+    assert dag_validator.ready_node_ids(dag, ["a"]) == ["b", "c"]
+    assert dag_validator.ready_node_ids(dag, ["a", "b", "c"]) == ["d"]
+
+
+def test_architect_plan_serializes_global_dag_and_state_refs():
+    job = {
+        "job_id": "job-1",
+        "system_state_refs": ["state://module/core", "state://manifest/current"],
+        "task_graph": [
+            {"task_id": "a", "task_type": "write docs", "blocked_by": [], "tier": 2},
+            {"task_id": "b", "task_type": "implement code", "blocked_by": ["a"], "tier": 2},
+        ],
+    }
+
+    plan = tier1_architect.architect_global_plan(job)
+    payload = plan.to_dict()
+    restored = tier_contracts.ArchitectPlan.from_dict(payload)
+
+    assert restored.root_job_id == "job-1"
+    assert restored.system_state_refs == ["state://module/core", "state://manifest/current"]
+    assert [n.node_id for n in restored.global_dag.nodes] == ["a", "b"]
+    assert restored.validation_errors == []
+    assert restored.tier_assignments == {"a": 2, "b": 2}
+
+
+def test_assign_task_slices_preserves_dependency_and_parent_lineage():
+    dag = _dag([
+        tier_contracts.PlanNode("a", "root", []),
+        tier_contracts.PlanNode("b", "child", ["a"], parent_node_id="global-b"),
+    ])
+
+    slices = tier2_decomposer.assign_task_slices(
+        dag,
+        node_tools={"a": [], "b": []},
+        allowed_tools=[],
+        model_class_map={"a": "llm", "b": "slm"},
+    )
+
+    assert slices[0].depends_on == []
+    assert slices[0].parent_node_id == "a"
+    assert slices[1].depends_on == ["a"]
+    assert slices[1].parent_node_id == "global-b"
+    assert slices[1].model_class == "slm"
+
+
+def test_tier1_dispatch_returns_valid_global_plan_and_slices():
+    job = {
+        "job_id": "job-2",
+        "system_state_refs": ["state://repo/head"],
+        "task_graph": [
+            {"task_id": "doc", "task_type": "write README docs", "blocked_by": [], "tier": 2},
+            {"task_id": "code", "task_type": "implement code", "blocked_by": ["doc"], "tier": 2},
+        ],
+    }
+
+    result = tier_dispatcher.dispatch_to_tier(1, job)
+
+    assert result["dispatched"] is True
+    assert result["architect_plan"]["root_job_id"] == "job-2"
+    assert result["architect_plan"]["system_state_refs"] == ["state://repo/head"]
+    assert result["validation"] == []
+    assert result["task_slices"][0]["model_class"] == "slm"
+    assert result["task_slices"][1]["depends_on"] == ["doc"]
+
+
+def test_tier2_dispatch_rejects_invalid_dag_before_slicing():
+    job = {
+        "job_id": "bad-job",
+        "task_graph": [
+            {"task_id": "a", "task_type": "first", "blocked_by": [], "tier": 2},
+            {"task_id": "a", "task_type": "duplicate", "blocked_by": [], "tier": 2},
+        ],
+    }
+
+    result = tier_dispatcher.dispatch_to_tier(2, job)
+
+    assert result["dispatched"] is False
+    assert result["reason"] == "invalid_dag"
+    assert "duplicate_node_id: a" in result["validation"]


### PR DESCRIPTION
## Summary
- adds ArchitectPlan/GlobalPlan-style contract for Tier-1 global DAG evidence
- strengthens DAG validation with deterministic topological order, ready-node calculation, and lineage checks
- preserves dependency/parent lineage in TaskSlice outputs
- wires Tier-1 dispatch to return validated global plans and Tier-2 dispatch to reject invalid DAGs before slicing
- adds Slice 14 roadmap doc and manifest regeneration

## Tests
- .\\.venv\\Scripts\\python.exe -m pytest -q tests/test_coding_agent_dag_correctness.py tests/test_coding_agent_tier1_architect.py tests/test_coding_agent_dispatcher_slm_routing.py
- .\\.venv\\Scripts\\python.exe -m pytest -q tests/test_schema_versioning.py
- .\\.venv\\Scripts\\python.exe -m pytest -q (5133 passed, 2 skipped, 14 warnings)