### PR TITLE
Slice 15: Tier-3 execution gating and retry policy

### DIFF
--- a/docs/MANIFEST.yaml
+++ b/docs/MANIFEST.yaml
@@ -36,6 +36,13 @@ artifacts:
   status: planned
   last_updated: 2026-06-29
   sha256: 30b5abd06617db949bebb5478f4b28d2c12c5f65aa7e91191689ab5259bc4a45
+- path: docs/roadmap/slices/15-tier3-execution-gating.md
+  type: doc
+  section: 0
+  doc_version: 1.0.0
+  status: planned
+  last_updated: 2026-06-29
+  sha256: 88c058c2267f99f9f6f427e6217aecd8dc59aa60bc4d0739771c6328d04ce2f1
 - path: docs/1-commands/README.md
   type: doc
   section: 1

--- a/docs/roadmap/slices/15-tier3-execution-gating.md
+++ b/docs/roadmap/slices/15-tier3-execution-gating.md
@@ -1,0 +1,32 @@
+---
+title: "Slice 15 — Tier-3 Execution Gating and Retry Policy"
+pack: model-packs/coding-agent/pack.yaml
+version: 0.9.0
+last_updated: 2026-06-29
+sha256: pending
+---
+
+Slice 15 enforces runtime-safe execution at Tier 3 by validating readiness
+before execution and applying deterministic retry policy for recoverable failures.
+
+## Purpose
+
+Tier 3 should execute only slices that are dependency-ready and within retry budget.
+This avoids wasted calls, duplicate execution, and retry storms.
+
+## Scope
+
+- Introduce an execution context contract for completed nodes and retry counters.
+- Add a readiness scheduler to validate whether a slice is executable.
+- Add deterministic retry classification and bounded exponential backoff.
+- Emit Tier-3 execution evidence for success, blocked, retry-scheduled, and failure outcomes.
+- Wire dispatcher enforcement for optional plan-aware gating while preserving backward compatibility.
+
+## Acceptance Criteria
+
+- Slices with unresolved dependencies are blocked when plan context is provided.
+- Recoverable failures produce retry scheduling metadata and backoff seconds.
+- Non-recoverable or exhausted-retry failures return deterministic failure outcomes.
+- Dispatcher returns structured Tier-3 evidence for all key execution outcomes.
+- Tests cover execution context, readiness gating, retry policy, and dispatcher behavior.
+- This document is tracked in `docs/MANIFEST.yaml` via `scripts/manifest-regenerate.ps1`.

--- a/model-packs/coding-agent/controllers/tier_dispatcher.py
+++ b/model-packs/coding-agent/controllers/tier_dispatcher.py
@@ -183,10 +183,74 @@ def dispatch_to_tier(tier: int, task_slice: Dict[str, Any]) -> Dict[str, Any]:
         return {"tier": tier, "dispatched": False, "reason": "not_implemented_yet"}
 
     # Validate TaskSlice shape
+    raw_task_slice = task_slice if isinstance(task_slice, dict) else {}
     try:
         ts = tier_contracts.TaskSlice.from_dict(task_slice)
     except Exception as exc:
         return {"tier": 3, "dispatched": False, "reason": f"invalid_task_slice: {exc}"}
+
+    # Robust load of tier-3 helpers (readiness scheduler, retry policy, evidence)
+    try:
+        from ..domain_lib import tier3_ready_scheduler, retry_policy, tier3_evidence
+    except Exception:
+        import importlib.util
+        import pathlib
+        import sys
+
+        base = pathlib.Path(__file__).parent
+
+        rs_path = base.parent / "domain-lib" / "tier3_ready_scheduler.py"
+        spec = importlib.util.spec_from_file_location("coding_agent_tier3_ready_scheduler", str(rs_path))
+        tier3_ready_scheduler = importlib.util.module_from_spec(spec)
+        sys.modules["coding_agent_tier3_ready_scheduler"] = tier3_ready_scheduler
+        spec.loader.exec_module(tier3_ready_scheduler)
+
+        rp_path = base.parent / "domain-lib" / "retry_policy.py"
+        spec = importlib.util.spec_from_file_location("coding_agent_retry_policy", str(rp_path))
+        retry_policy = importlib.util.module_from_spec(spec)
+        sys.modules["coding_agent_retry_policy"] = retry_policy
+        spec.loader.exec_module(retry_policy)
+
+        ev_path = base.parent / "domain-lib" / "tier3_evidence.py"
+        spec = importlib.util.spec_from_file_location("coding_agent_tier3_evidence", str(ev_path))
+        tier3_evidence = importlib.util.module_from_spec(spec)
+        sys.modules["coding_agent_tier3_evidence"] = tier3_evidence
+        spec.loader.exec_module(tier3_evidence)
+
+    execution_context = tier_contracts.ExecutionContext.from_dict(raw_task_slice.get("execution_context") or {})
+    attempt_count = int(execution_context.retry_counts.get(ts.node_id, 0))
+
+    # Optional readiness gate: only enforced when a plan is supplied by caller.
+    plan_data = raw_task_slice.get("plan") if isinstance(raw_task_slice, dict) else None
+    plan_dag = None
+    if isinstance(plan_data, dict):
+        try:
+            plan_dag = tier_contracts.PlanDAG.from_dict(plan_data)
+            readiness_errors = tier3_ready_scheduler.validate_slice_ready(ts, plan_dag, execution_context)
+            if readiness_errors:
+                evidence = tier3_evidence.Tier3ExecutionEvidence(
+                    slice_id=ts.slice_id,
+                    node_id=ts.node_id,
+                    model_class=ts.model_class,
+                    status="blocked",
+                    ready=False,
+                    retryable=False,
+                    attempt_count=attempt_count,
+                    error_class="not_ready",
+                    error_message="; ".join(readiness_errors),
+                    completed_node_ids=list(execution_context.completed_node_ids or []),
+                    denied_tools=[],
+                    allowed_tools=list(ts.allowed_tools or []),
+                )
+                return {
+                    "tier": 3,
+                    "dispatched": False,
+                    "reason": "slice_not_ready",
+                    "readiness_errors": readiness_errors,
+                    "tier3_evidence": evidence.to_dict(),
+                }
+        except Exception as exc:
+            return {"tier": 3, "dispatched": False, "reason": f"invalid_plan: {exc}"}
 
     # If the slice requests the SLM, use the lumina SLM API for document-style tasks.
     try:
@@ -205,9 +269,56 @@ def dispatch_to_tier(tier: int, task_slice: Dict[str, Any]) -> Dict[str, Any]:
                 # Use the slice description as the user payload; callers may later
                 # enrich this into a more structured prompt.
                 out = slm.call_slm(system="", user=ts.task_description)
-                return {"tier": 3, "dispatched": True, "model_class": "slm", "slm_output": out}
+                evidence = tier3_evidence.Tier3ExecutionEvidence(
+                    slice_id=ts.slice_id,
+                    node_id=ts.node_id,
+                    model_class="slm",
+                    status="success",
+                    ready=True,
+                    retryable=False,
+                    attempt_count=attempt_count,
+                    completed_node_ids=list(execution_context.completed_node_ids or []),
+                    denied_tools=[],
+                    allowed_tools=list(ts.allowed_tools or []),
+                )
+                return {
+                    "tier": 3,
+                    "dispatched": True,
+                    "model_class": "slm",
+                    "slm_output": out,
+                    "tier3_evidence": evidence.to_dict(),
+                }
             except Exception as exc:
-                return {"tier": 3, "dispatched": False, "reason": f"slm_failed: {exc}"}
+                failure = retry_policy.classify_failure(exc)
+                retryable = retry_policy.should_retry(failure, attempt_count, execution_context.max_retries_per_node)
+                backoff = retry_policy.next_backoff_seconds(
+                    attempt_count,
+                    execution_context.base_backoff_seconds,
+                    execution_context.max_backoff_seconds,
+                )
+                evidence = tier3_evidence.Tier3ExecutionEvidence(
+                    slice_id=ts.slice_id,
+                    node_id=ts.node_id,
+                    model_class="slm",
+                    status="retry_scheduled" if retryable else "failed",
+                    ready=True,
+                    retryable=retryable,
+                    retry_after_seconds=backoff if retryable else 0.0,
+                    attempt_count=attempt_count,
+                    error_class=failure,
+                    error_message=str(exc),
+                    completed_node_ids=list(execution_context.completed_node_ids or []),
+                    denied_tools=[],
+                    allowed_tools=list(ts.allowed_tools or []),
+                )
+                return {
+                    "tier": 3,
+                    "dispatched": False,
+                    "reason": "retry_scheduled" if retryable else f"slm_failed: {exc}",
+                    "retryable": retryable,
+                    "retry_after_seconds": backoff if retryable else 0.0,
+                    "tier3_evidence": evidence.to_dict(),
+                }
         # else: fallthrough to adapter execution path
 
     denied = []
@@ -221,9 +332,30 @@ def dispatch_to_tier(tier: int, task_slice: Dict[str, Any]) -> Dict[str, Any]:
         allowed.append(tool_id)
 
     if not allowed:
-        return {"tier": 3, "dispatched": False, "allowed_tools": allowed, "denied_tools": denied}
+        evidence = tier3_evidence.Tier3ExecutionEvidence(
+            slice_id=ts.slice_id,
+            node_id=ts.node_id,
+            model_class=model_class,
+            status="blocked",
+            ready=True,
+            retryable=False,
+            attempt_count=attempt_count,
+            error_class="no_allowed_tools",
+            error_message="no tools were allowed for this slice",
+            completed_node_ids=list(execution_context.completed_node_ids or []),
+            denied_tools=list(denied),
+            allowed_tools=list(allowed),
+        )
+        return {
+            "tier": 3,
+            "dispatched": False,
+            "allowed_tools": allowed,
+            "denied_tools": denied,
+            "tier3_evidence": evidence.to_dict(),
+        }
 
     # Execute each allowed tool with a minimal payload (TaskSlice-driven); callers may provide tool-specific payloads later.
+    first_failure = ""
     for tool_id in allowed:
         backing = registry[tool_id]
         # call with a conservative, safe payload per adapter signature
@@ -243,6 +375,15 @@ def dispatch_to_tier(tier: int, task_slice: Dict[str, Any]) -> Dict[str, Any]:
         except Exception as exc:  # defensive
             result = {"error": str(exc)}
 
+        if not first_failure:
+            if isinstance(result, dict):
+                if result.get("error"):
+                    first_failure = str(result.get("error"))
+                elif result.get("read_ok") is False:
+                    first_failure = str(result.get("error") or "read_failed")
+                elif result.get("write_ok") is False:
+                    first_failure = str(result.get("error") or "write_failed")
+
         step = {
             "tool_id": tool_id,
             "payload": payload,
@@ -252,5 +393,59 @@ def dispatch_to_tier(tier: int, task_slice: Dict[str, Any]) -> Dict[str, Any]:
 
     # Use classmethod for construction to be robust across versions
     seq_trace = sequential_thinking_schema.SequentialThinkingTrace.from_steps(trace)
+    if first_failure:
+        failure = retry_policy.classify_failure(first_failure)
+        retryable = retry_policy.should_retry(failure, attempt_count, execution_context.max_retries_per_node)
+        backoff = retry_policy.next_backoff_seconds(
+            attempt_count,
+            execution_context.base_backoff_seconds,
+            execution_context.max_backoff_seconds,
+        )
+        evidence = tier3_evidence.Tier3ExecutionEvidence(
+            slice_id=ts.slice_id,
+            node_id=ts.node_id,
+            model_class=model_class,
+            status="retry_scheduled" if retryable else "failed",
+            ready=True,
+            retryable=retryable,
+            retry_after_seconds=backoff if retryable else 0.0,
+            attempt_count=attempt_count,
+            error_class=failure,
+            error_message=first_failure,
+            completed_node_ids=list(execution_context.completed_node_ids or []),
+            denied_tools=list(denied),
+            allowed_tools=list(allowed),
+        )
+        return {
+            "tier": 3,
+            "dispatched": False,
+            "allowed_tools": allowed,
+            "denied_tools": denied,
+            "scratchpad": seq_trace.to_dict(),
+            "reason": "retry_scheduled" if retryable else "tier3_execution_failed",
+            "retryable": retryable,
+            "retry_after_seconds": backoff if retryable else 0.0,
+            "tier3_evidence": evidence.to_dict(),
+        }
 
-    return {"tier": 3, "dispatched": True, "allowed_tools": allowed, "denied_tools": denied, "scratchpad": seq_trace.to_dict()}
+    evidence = tier3_evidence.Tier3ExecutionEvidence(
+        slice_id=ts.slice_id,
+        node_id=ts.node_id,
+        model_class=model_class,
+        status="success",
+        ready=True,
+        retryable=False,
+        attempt_count=attempt_count,
+        completed_node_ids=list(execution_context.completed_node_ids or []),
+        denied_tools=list(denied),
+        allowed_tools=list(allowed),
+    )
+
+    return {
+        "tier": 3,
+        "dispatched": True,
+        "allowed_tools": allowed,
+        "denied_tools": denied,
+        "scratchpad": seq_trace.to_dict(),
+        "tier3_evidence": evidence.to_dict(),
+    }

--- a/model-packs/coding-agent/domain-lib/retry_policy.py
+++ b/model-packs/coding-agent/domain-lib/retry_policy.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def classify_failure(error: Any) -> str:
+    message = str(error or "").lower()
+
+    if not message:
+        return "unknown"
+    if "timeout" in message or "temporar" in message or "connection" in message:
+        return "transient"
+    if "rate limit" in message or "429" in message:
+        return "rate_limit"
+    if "unauthorized" in message or "forbidden" in message or "permission" in message:
+        return "auth"
+    if "invalid" in message or "validation" in message or "schema" in message:
+        return "validation"
+    return "tool_error"
+
+
+def should_retry(failure_class: str, attempt_count: int, max_retries: int) -> bool:
+    if attempt_count >= max_retries:
+        return False
+    return failure_class in {"transient", "rate_limit", "unknown"}
+
+
+def next_backoff_seconds(
+    attempt_count: int,
+    base_backoff_seconds: float = 1.0,
+    max_backoff_seconds: float = 30.0,
+) -> float:
+    attempt = max(0, int(attempt_count))
+    backoff = float(base_backoff_seconds) * (2 ** attempt)
+    return min(float(max_backoff_seconds), backoff)

--- a/model-packs/coding-agent/domain-lib/tier3_evidence.py
+++ b/model-packs/coding-agent/domain-lib/tier3_evidence.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict, field
+from datetime import datetime
+from typing import Any, Dict, List
+
+
+@dataclass
+class Tier3ExecutionEvidence:
+    slice_id: str
+    node_id: str
+    model_class: str
+    status: str
+    ready: bool
+    retryable: bool
+    retry_after_seconds: float = 0.0
+    attempt_count: int = 0
+    error_class: str = ""
+    error_message: str = ""
+    completed_node_ids: List[str] = field(default_factory=list)
+    denied_tools: List[str] = field(default_factory=list)
+    allowed_tools: List[str] = field(default_factory=list)
+    created_at: str = field(default_factory=lambda: datetime.utcnow().isoformat() + "Z")
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Tier3ExecutionEvidence":
+        payload = data or {}
+        return cls(
+            slice_id=str(payload.get("slice_id", "")),
+            node_id=str(payload.get("node_id", "")),
+            model_class=str(payload.get("model_class", "llm")),
+            status=str(payload.get("status", "unknown")),
+            ready=bool(payload.get("ready", False)),
+            retryable=bool(payload.get("retryable", False)),
+            retry_after_seconds=float(payload.get("retry_after_seconds", 0.0)),
+            attempt_count=int(payload.get("attempt_count", 0)),
+            error_class=str(payload.get("error_class", "")),
+            error_message=str(payload.get("error_message", "")),
+            completed_node_ids=[str(x) for x in list(payload.get("completed_node_ids") or [])],
+            denied_tools=[str(x) for x in list(payload.get("denied_tools") or [])],
+            allowed_tools=[str(x) for x in list(payload.get("allowed_tools") or [])],
+            created_at=str(payload.get("created_at", datetime.utcnow().isoformat() + "Z")),
+        )

--- a/model-packs/coding-agent/domain-lib/tier3_ready_scheduler.py
+++ b/model-packs/coding-agent/domain-lib/tier3_ready_scheduler.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from typing import List
+
+# Robust imports: allow module to be loaded as a standalone file during tests
+try:
+    from . import dag_validator, tier_contracts
+except Exception:
+    import importlib.util
+    import pathlib
+    import sys
+
+    base = pathlib.Path(__file__).parent
+
+    dv_path = base / "dag_validator.py"
+    spec = importlib.util.spec_from_file_location("coding_agent_dag_validator", str(dv_path))
+    dag_validator = importlib.util.module_from_spec(spec)
+    sys.modules["coding_agent_dag_validator"] = dag_validator
+    spec.loader.exec_module(dag_validator)
+
+    tc_path = base / "tier_contracts.py"
+    spec = importlib.util.spec_from_file_location("coding_agent_tier_contracts", str(tc_path))
+    tier_contracts = importlib.util.module_from_spec(spec)
+    sys.modules["coding_agent_tier_contracts"] = tier_contracts
+    spec.loader.exec_module(tier_contracts)
+
+
+PlanDAG = tier_contracts.PlanDAG
+TaskSlice = tier_contracts.TaskSlice
+ExecutionContext = tier_contracts.ExecutionContext
+
+
+def is_node_ready(node_id: str, dag: PlanDAG, execution_context: ExecutionContext) -> bool:
+    completed = set(execution_context.completed_node_ids or [])
+    ready = dag_validator.ready_node_ids(dag, completed)
+    return node_id in ready
+
+
+def validate_slice_ready(task_slice: TaskSlice, dag: PlanDAG, execution_context: ExecutionContext) -> List[str]:
+    errors: List[str] = []
+    node_ids = {n.node_id for n in dag.nodes}
+
+    if task_slice.node_id not in node_ids:
+        errors.append(f"unknown_slice_node: {task_slice.node_id}")
+        return errors
+
+    if task_slice.node_id in set(execution_context.completed_node_ids or []):
+        errors.append(f"already_completed: {task_slice.node_id}")
+
+    if task_slice.node_id in set(execution_context.failed_node_ids or []):
+        errors.append(f"failed_node_blocked: {task_slice.node_id}")
+
+    if not is_node_ready(task_slice.node_id, dag, execution_context):
+        completed = set(execution_context.completed_node_ids or [])
+        for dep in task_slice.depends_on or []:
+            if dep not in completed:
+                errors.append(f"dependency_not_ready: {task_slice.node_id} -> {dep}")
+
+    return errors
+
+
+def next_ready_slices(
+    dag: PlanDAG,
+    slices: List[TaskSlice],
+    execution_context: ExecutionContext,
+) -> List[TaskSlice]:
+    completed = set(execution_context.completed_node_ids or [])
+    failed = set(execution_context.failed_node_ids or [])
+    ready_ids = set(dag_validator.ready_node_ids(dag, completed))
+
+    ordered = []
+    slice_by_node = {s.node_id: s for s in slices}
+    for node in dag_validator.stable_topological_sort(dag):
+        node_id = node.node_id
+        if node_id in completed or node_id in failed:
+            continue
+        if node_id not in ready_ids:
+            continue
+        if node_id in slice_by_node:
+            ordered.append(slice_by_node[node_id])
+
+    return ordered

--- a/model-packs/coding-agent/domain-lib/tier_contracts.py
+++ b/model-packs/coding-agent/domain-lib/tier_contracts.py
@@ -98,3 +98,35 @@ class TaskSlice:
             depends_on=list(data.get("depends_on") or []),
             parent_node_id=str(data.get("parent_node_id", "")),
         )
+
+
+@dataclass
+class ExecutionContext:
+    completed_node_ids: List[str] = field(default_factory=list)
+    failed_node_ids: List[str] = field(default_factory=list)
+    retry_counts: Dict[str, int] = field(default_factory=dict)
+    max_retries_per_node: int = 2
+    base_backoff_seconds: float = 1.0
+    max_backoff_seconds: float = 30.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "completed_node_ids": list(self.completed_node_ids or []),
+            "failed_node_ids": list(self.failed_node_ids or []),
+            "retry_counts": {str(k): int(v) for k, v in dict(self.retry_counts or {}).items()},
+            "max_retries_per_node": int(self.max_retries_per_node),
+            "base_backoff_seconds": float(self.base_backoff_seconds),
+            "max_backoff_seconds": float(self.max_backoff_seconds),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any] | None) -> "ExecutionContext":
+        payload = data or {}
+        return cls(
+            completed_node_ids=[str(x) for x in list(payload.get("completed_node_ids") or [])],
+            failed_node_ids=[str(x) for x in list(payload.get("failed_node_ids") or [])],
+            retry_counts={str(k): int(v) for k, v in dict(payload.get("retry_counts") or {}).items()},
+            max_retries_per_node=int(payload.get("max_retries_per_node", 2)),
+            base_backoff_seconds=float(payload.get("base_backoff_seconds", 1.0)),
+            max_backoff_seconds=float(payload.get("max_backoff_seconds", 30.0)),
+        )

--- a/tests/test_coding_agent_tier3_gating_and_retry.py
+++ b/tests/test_coding_agent_tier3_gating_and_retry.py
@@ -1,0 +1,170 @@
+import importlib.util
+import pathlib
+import sys
+import types
+
+BASE = pathlib.Path(__file__).parent.parent / "model-packs" / "coding-agent"
+DOMAIN = BASE / "domain-lib"
+CONTROLLERS = BASE / "controllers"
+
+
+def _load(name: str, path: pathlib.Path):
+    spec = importlib.util.spec_from_file_location(name, str(path))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+tier_contracts = _load("coding_agent_tier_contracts_slice15", DOMAIN / "tier_contracts.py")
+tier3_ready_scheduler = _load("coding_agent_tier3_ready_scheduler_slice15", DOMAIN / "tier3_ready_scheduler.py")
+retry_policy = _load("coding_agent_retry_policy_slice15", DOMAIN / "retry_policy.py")
+tier_dispatcher = _load("coding_agent_tier_dispatcher_slice15", CONTROLLERS / "tier_dispatcher.py")
+
+
+def _make_plan():
+    dag = tier_contracts.PlanDAG(
+        nodes=[
+            tier_contracts.PlanNode("A", "prep docs", []),
+            tier_contracts.PlanNode("B", "write docs", ["A"]),
+        ],
+        created_at="now",
+    )
+    return dag.to_dict()
+
+
+def _make_slice(node_id: str = "B"):
+    return {
+        "slice_id": f"{node_id}-slice",
+        "node_id": node_id,
+        "task_description": "Write README docs",
+        "allowed_tools": ["adapter/ca/write-file/v1"],
+        "context_budget_tokens": 1024,
+        "tier": 3,
+        "model_class": "llm",
+        "depends_on": ["A"] if node_id == "B" else [],
+    }
+
+
+def test_ready_scheduler_blocks_unmet_dependencies():
+    dag = tier_contracts.PlanDAG.from_dict(_make_plan())
+    task_slice = tier_contracts.TaskSlice.from_dict(_make_slice("B"))
+    ctx = tier_contracts.ExecutionContext.from_dict({"completed_node_ids": []})
+
+    errors = tier3_ready_scheduler.validate_slice_ready(task_slice, dag, ctx)
+
+    assert any(e.startswith("dependency_not_ready:") for e in errors)
+
+
+def test_dispatcher_blocks_not_ready_slice_when_plan_provided():
+    payload = _make_slice("B")
+    payload["plan"] = _make_plan()
+    payload["execution_context"] = {"completed_node_ids": []}
+
+    out = tier_dispatcher.dispatch_to_tier(3, payload)
+
+    assert out["dispatched"] is False
+    assert out["reason"] == "slice_not_ready"
+    assert out["tier3_evidence"]["status"] == "blocked"
+
+
+def test_dispatcher_runs_ready_slm_slice(monkeypatch):
+    slm_mod = types.SimpleNamespace()
+    slm_mod.slm_available = lambda: True
+    slm_mod.call_slm = lambda system, user, model=None, max_tokens=None: "SLM_OK"
+
+    lumina = types.ModuleType("lumina")
+    core = types.ModuleType("lumina.core")
+    core.slm = slm_mod
+    lumina.core = core
+
+    monkeypatch.setitem(sys.modules, "lumina", lumina)
+    monkeypatch.setitem(sys.modules, "lumina.core", core)
+    monkeypatch.setitem(sys.modules, "lumina.core.slm", slm_mod)
+
+    payload = {
+        "slice_id": "A-slice",
+        "node_id": "A",
+        "task_description": "Write docs",
+        "allowed_tools": [],
+        "tier": 3,
+        "model_class": "slm",
+        "depends_on": [],
+        "plan": _make_plan(),
+        "execution_context": {"completed_node_ids": []},
+    }
+
+    out = tier_dispatcher.dispatch_to_tier(3, payload)
+
+    assert out["dispatched"] is True
+    assert out["model_class"] == "slm"
+    assert out["tier3_evidence"]["status"] == "success"
+
+
+def test_dispatcher_schedules_retry_for_retryable_failure(monkeypatch):
+    slm_mod = types.SimpleNamespace()
+    slm_mod.slm_available = lambda: True
+
+    def _raise_timeout(system, user, model=None, max_tokens=None):
+        raise TimeoutError("temporary timeout")
+
+    slm_mod.call_slm = _raise_timeout
+    lumina = types.ModuleType("lumina")
+    core = types.ModuleType("lumina.core")
+    core.slm = slm_mod
+    lumina.core = core
+    monkeypatch.setitem(sys.modules, "lumina", lumina)
+    monkeypatch.setitem(sys.modules, "lumina.core", core)
+    monkeypatch.setitem(sys.modules, "lumina.core.slm", slm_mod)
+
+    payload = {
+        "slice_id": "A-slice",
+        "node_id": "A",
+        "task_description": "Write docs",
+        "allowed_tools": [],
+        "tier": 3,
+        "model_class": "slm",
+        "depends_on": [],
+        "plan": _make_plan(),
+        "execution_context": {
+            "completed_node_ids": [],
+            "retry_counts": {"A": 0},
+            "max_retries_per_node": 2,
+            "base_backoff_seconds": 1.0,
+            "max_backoff_seconds": 30.0,
+        },
+    }
+
+    out = tier_dispatcher.dispatch_to_tier(3, payload)
+
+    assert out["dispatched"] is False
+    assert out["reason"] == "retry_scheduled"
+    assert out["retryable"] is True
+    assert out["retry_after_seconds"] > 0
+    assert out["tier3_evidence"]["status"] == "retry_scheduled"
+
+
+def test_dispatcher_stops_retry_when_budget_exhausted():
+    payload = _make_slice("A")
+    payload["plan"] = _make_plan()
+    payload["execution_context"] = {
+        "completed_node_ids": [],
+        "retry_counts": {"A": 2},
+        "max_retries_per_node": 2,
+    }
+
+    out = tier_dispatcher.dispatch_to_tier(3, payload)
+
+    assert out["dispatched"] is False
+    assert out["reason"] == "tier3_execution_failed"
+    assert out["retryable"] is False
+    assert out["tier3_evidence"]["status"] == "failed"
+
+
+def test_retry_policy_backoff_is_bounded_and_exponential():
+    assert retry_policy.classify_failure("temporary timeout") == "transient"
+    assert retry_policy.should_retry("transient", attempt_count=0, max_retries=2) is True
+    assert retry_policy.should_retry("validation", attempt_count=0, max_retries=2) is False
+    assert retry_policy.next_backoff_seconds(0, 1.0, 30.0) == 1.0
+    assert retry_policy.next_backoff_seconds(1, 1.0, 30.0) == 2.0
+    assert retry_policy.next_backoff_seconds(10, 1.0, 30.0) == 30.0

--- a/tests/test_coding_agent_tier_contracts.py
+++ b/tests/test_coding_agent_tier_contracts.py
@@ -60,3 +60,23 @@ def test_dispatch_to_tier_3_runs_allowed_tools():
     # scratchpad should be present and contain steps
     sp = result.get("scratchpad")
     assert sp and isinstance(sp.get("steps"), list)
+
+
+def test_execution_context_round_trip():
+    ctx = tier_contracts.ExecutionContext(
+        completed_node_ids=["A"],
+        failed_node_ids=["B"],
+        retry_counts={"C": 1},
+        max_retries_per_node=3,
+        base_backoff_seconds=2.0,
+        max_backoff_seconds=40.0,
+    )
+
+    restored = tier_contracts.ExecutionContext.from_dict(ctx.to_dict())
+
+    assert restored.completed_node_ids == ["A"]
+    assert restored.failed_node_ids == ["B"]
+    assert restored.retry_counts == {"C": 1}
+    assert restored.max_retries_per_node == 3
+    assert restored.base_backoff_seconds == 2.0
+    assert restored.max_backoff_seconds == 40.0


### PR DESCRIPTION
## Summary
- add ExecutionContext contract for completed nodes and retry counters
- add Tier-3 readiness scheduler to gate execution by DAG readiness
- add deterministic retry policy with bounded exponential backoff
- add Tier3ExecutionEvidence and wire dispatcher outcomes
- add Slice 15 roadmap doc and regenerate docs/MANIFEST.yaml
- add focused Tier-3 gating/retry tests and contract round-trip coverage

## Validation
- pytest -q tests/test_coding_agent_tier3_gating_and_retry.py tests/test_coding_agent_tier_contracts.py tests/test_coding_agent_dispatcher_slm_routing.py tests/test_coding_agent_dag_correctness.py
  - 20 passed
