### PR TITLE
Slice 16: Execution State Persistence & Checkpoint Recovery

### DIFF
--- a/docs/MANIFEST.yaml
+++ b/docs/MANIFEST.yaml
@@ -43,6 +43,13 @@ artifacts:
   status: planned
   last_updated: 2026-06-29
   sha256: 88c058c2267f99f9f6f427e6217aecd8dc59aa60bc4d0739771c6328d04ce2f1
+- path: docs/roadmap/slices/16-execution-state-persistence.md
+  type: doc
+  section: 0
+  doc_version: 1.0.0
+  status: planned
+  last_updated: 2026-06-30
+  sha256: 84d5316b61a12bd8228b7750625177969e4bfdf704fd434ca8b74926bd111866
 - path: docs/1-commands/README.md
   type: doc
   section: 1

--- a/docs/MANIFEST.yaml
+++ b/docs/MANIFEST.yaml
@@ -1,5 +1,5 @@
 ﻿schema_version: 1.0.0
-last_updated: 2026-06-29
+last_updated: 2026-06-30
 artifacts:
 - path: docs/5-standards/manifest-regen-policy.md
   type: doc

--- a/docs/roadmap/slices/16-execution-state-persistence.md
+++ b/docs/roadmap/slices/16-execution-state-persistence.md
@@ -1,0 +1,20 @@
+---
+title: "Slice 16 — Execution State Persistence & Checkpoint Recovery"
+slice: 16
+status: draft
+sha256: pending
+---
+
+Summary
+-------
+
+This slice implements persistent execution-state checkpoints for the coding-agent pack so Tier-3 execution progress, retry counters, and failure context survive across turns. It enables deterministic resume, bounded retention of checkpoints, and a compatibility bridge for callers that do not provide persisted state.
+
+Key points
+- Persistence lives in-pack (in-state serialized) to avoid external dependencies.
+- Checkpoints include plan id, checkpoint id, timestamp, source, and serialized `ExecutionContext`.
+- Retention default: keep last 10 checkpoints per plan.
+- Runtime restores latest checkpoint before Tier-3 dispatch and saves updated checkpoint after dispatch.
+
+Notes
+- After adding or editing this file run `scripts/manifest-regenerate.ps1` to update `docs/MANIFEST.yaml`.

--- a/docs/roadmap/slices/16-execution-state-persistence.md
+++ b/docs/roadmap/slices/16-execution-state-persistence.md
@@ -1,7 +1,10 @@
 ---
 title: "Slice 16 — Execution State Persistence & Checkpoint Recovery"
 slice: 16
-status: draft
+pack: model-packs/coding-agent/pack.yaml
+status: planned
+version: 0.1.0
+last_updated: 2026-06-30
 sha256: pending
 ---
 

--- a/model-packs/coding-agent/controllers/runtime_adapters.py
+++ b/model-packs/coding-agent/controllers/runtime_adapters.py
@@ -32,6 +32,44 @@ def build_initial_state(profile: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _load_execution_modules():
+    try:
+        from model_packs.coding_agent.domain_lib import execution_state_store as _store
+        from model_packs.coding_agent.domain_lib import tier_contracts as _contracts
+        return _store, _contracts
+    except Exception:
+        import importlib.util
+        import pathlib
+        import sys
+
+        base = pathlib.Path(__file__).parent.parent
+
+        store_path = base / "domain-lib" / "execution_state_store.py"
+        spec = importlib.util.spec_from_file_location("coding_agent_execution_state_store", str(store_path))
+        _store = importlib.util.module_from_spec(spec)
+        sys.modules["coding_agent_execution_state_store"] = _store
+        spec.loader.exec_module(_store)
+
+        contracts_path = base / "domain-lib" / "tier_contracts.py"
+        spec = importlib.util.spec_from_file_location("coding_agent_tier_contracts_runtime", str(contracts_path))
+        _contracts = importlib.util.module_from_spec(spec)
+        sys.modules["coding_agent_tier_contracts_runtime"] = _contracts
+        spec.loader.exec_module(_contracts)
+
+        return _store, _contracts
+
+
+def _resolve_plan_id(task_slice: dict[str, Any], task_spec: dict[str, Any]) -> str:
+    if not isinstance(task_slice, dict):
+        return str(task_spec.get("task_id") or "default")
+    if task_slice.get("plan_id"):
+        return str(task_slice.get("plan_id"))
+    plan = task_slice.get("plan") if isinstance(task_slice.get("plan"), dict) else {}
+    if plan.get("plan_id"):
+        return str(plan.get("plan_id"))
+    return str(task_spec.get("task_id") or "default")
+
+
 def domain_step(
     state: dict[str, Any],
     task_spec: dict[str, Any],
@@ -139,6 +177,13 @@ def domain_step(
             except Exception:
                 return new_state, {"action": "dispatch_failed", "reason": "dispatcher_missing"}
 
+        try:
+            _store, _contracts = _load_execution_modules()
+            state_store = _store.ExecutionStateStore.from_dict(new_state.get("execution_state_store") or {})
+        except Exception:
+            state_store = None
+            _contracts = None
+
         # execution_tier expected from micro_context if present
         execution_tier = None
         micro = evidence.get("micro_context") or {}
@@ -146,7 +191,33 @@ def domain_step(
         if execution_tier is None:
             execution_tier = 3
 
-        dispatch_result = _td.dispatch_to_tier(int(execution_tier), evidence.get("task_slice"))
+        task_slice_payload = dict(evidence.get("task_slice") or {})
+
+        if int(execution_tier) == 3 and state_store is not None and _contracts is not None:
+            plan_id = _resolve_plan_id(task_slice_payload, task_spec)
+            latest = state_store.load_latest_checkpoint(plan_id)
+            if latest is not None:
+                restored_context = _contracts.ExecutionContext.from_dict(latest.execution_context)
+            else:
+                restored_context = _contracts.ExecutionContext.from_dict(task_slice_payload.get("execution_context") or {})
+
+            dispatch_result = _td.dispatch_to_tier_with_state(
+                3,
+                task_slice_payload,
+                execution_context=restored_context.to_dict(),
+            )
+
+            persisted_context = dispatch_result.get("execution_context") if isinstance(dispatch_result, dict) else None
+            if isinstance(persisted_context, dict):
+                source = "tier3_dispatch"
+                tier3_evidence = dispatch_result.get("tier3_evidence")
+                if isinstance(tier3_evidence, dict) and tier3_evidence.get("status"):
+                    source = f"tier3_{tier3_evidence.get('status')}"
+                state_store.save_checkpoint(plan_id, persisted_context, source=source)
+                new_state["execution_state_store"] = state_store.to_dict()
+        else:
+            dispatch_result = _td.dispatch_to_tier(int(execution_tier), task_slice_payload)
+
         return new_state, {"action": "dispatched", "dispatch_result": dispatch_result}
 
     # Tier-2 planning: if micro-context prefers tier 2 and a job payload exists, decompose

--- a/model-packs/coding-agent/controllers/tier_dispatcher.py
+++ b/model-packs/coding-agent/controllers/tier_dispatcher.py
@@ -44,6 +44,63 @@ def _resolve_tool_registry() -> Dict[str, Any]:
     }
 
 
+def _update_execution_context_for_result(
+    execution_context: Any,
+    task_slice: Dict[str, Any],
+    dispatch_result: Dict[str, Any],
+) -> Any:
+    node_id = str(task_slice.get("node_id", ""))
+    if not node_id:
+        return execution_context
+
+    evidence = dispatch_result.get("tier3_evidence") if isinstance(dispatch_result, dict) else None
+    status = str((evidence or {}).get("status", "")) if isinstance(evidence, dict) else ""
+    retryable = bool(dispatch_result.get("retryable", False)) if isinstance(dispatch_result, dict) else False
+
+    completed = list(execution_context.completed_node_ids or [])
+    failed = list(execution_context.failed_node_ids or [])
+    retries = dict(execution_context.retry_counts or {})
+
+    if status == "success":
+        if node_id not in completed:
+            completed.append(node_id)
+        if node_id in failed:
+            failed = [value for value in failed if value != node_id]
+        retries.pop(node_id, None)
+    elif status == "retry_scheduled" or retryable:
+        retries[node_id] = int(retries.get(node_id, 0)) + 1
+    elif status == "failed":
+        if node_id not in failed:
+            failed.append(node_id)
+
+    execution_context.completed_node_ids = completed
+    execution_context.failed_node_ids = failed
+    execution_context.retry_counts = {str(key): int(value) for key, value in retries.items()}
+    return execution_context
+
+
+def dispatch_to_tier_with_state(
+    tier: int,
+    task_slice: Dict[str, Any],
+    execution_context: Dict[str, Any] | None = None,
+) -> Dict[str, Any]:
+    raw = dict(task_slice or {})
+    payload_context = execution_context if isinstance(execution_context, dict) else {}
+    if not raw.get("execution_context"):
+        raw["execution_context"] = payload_context
+
+    result = dispatch_to_tier(tier, raw)
+
+    try:
+        current_context = tier_contracts.ExecutionContext.from_dict(raw.get("execution_context") or {})
+        updated = _update_execution_context_for_result(current_context, raw, result)
+        result["execution_context"] = updated.to_dict()
+    except Exception:
+        result["execution_context"] = payload_context
+
+    return result
+
+
 def dispatch_to_tier(tier: int, task_slice: Dict[str, Any]) -> Dict[str, Any]:
     registry = _resolve_tool_registry()
 

--- a/model-packs/coding-agent/domain-lib/execution_state_store.py
+++ b/model-packs/coding-agent/domain-lib/execution_state_store.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+from uuid import uuid4
+
+
+@dataclass
+class ExecutionCheckpoint:
+    plan_id: str
+    checkpoint_id: str
+    execution_context: Dict[str, Any]
+    timestamp: str
+    source: str = "runtime"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "plan_id": str(self.plan_id),
+            "checkpoint_id": str(self.checkpoint_id),
+            "execution_context": dict(self.execution_context or {}),
+            "timestamp": str(self.timestamp),
+            "source": str(self.source or "runtime"),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any] | None) -> "ExecutionCheckpoint":
+        payload = data or {}
+        return cls(
+            plan_id=str(payload.get("plan_id", "")),
+            checkpoint_id=str(payload.get("checkpoint_id") or uuid4()),
+            execution_context=dict(payload.get("execution_context") or {}),
+            timestamp=str(payload.get("timestamp") or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")),
+            source=str(payload.get("source") or "runtime"),
+        )
+
+
+@dataclass
+class ExecutionStateStore:
+    checkpoints: List[ExecutionCheckpoint] = field(default_factory=list)
+    retention_limit: int = 10
+
+    def save_checkpoint(self, plan_id: str, execution_context: Dict[str, Any], source: str = "runtime") -> ExecutionCheckpoint:
+        checkpoint = ExecutionCheckpoint(
+            plan_id=str(plan_id or "default"),
+            checkpoint_id=str(uuid4()),
+            execution_context=dict(execution_context or {}),
+            timestamp=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            source=str(source or "runtime"),
+        )
+        self.checkpoints.append(checkpoint)
+        self._prune_for_plan(checkpoint.plan_id)
+        return checkpoint
+
+    def load_latest_checkpoint(self, plan_id: str) -> ExecutionCheckpoint | None:
+        normalized = str(plan_id or "default")
+        matches = [c for c in self.checkpoints if c.plan_id == normalized]
+        if not matches:
+            return None
+        return matches[-1]
+
+    def list_checkpoints(self, plan_id: str | None = None) -> List[ExecutionCheckpoint]:
+        if plan_id is None:
+            matches = list(self.checkpoints)
+        else:
+            normalized = str(plan_id or "default")
+            matches = [c for c in self.checkpoints if c.plan_id == normalized]
+        return matches
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "retention_limit": int(self.retention_limit),
+            "checkpoints": [checkpoint.to_dict() for checkpoint in self.list_checkpoints()],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any] | None) -> "ExecutionStateStore":
+        payload = data or {}
+        retention = int(payload.get("retention_limit", 10))
+        retention = max(1, retention)
+        checkpoints = [ExecutionCheckpoint.from_dict(item) for item in list(payload.get("checkpoints") or [])]
+        store = cls(checkpoints=checkpoints, retention_limit=retention)
+
+        for plan_id in {c.plan_id for c in checkpoints}:
+            store._prune_for_plan(plan_id)
+        return store
+
+    def _prune_for_plan(self, plan_id: str) -> None:
+        normalized = str(plan_id or "default")
+        plan_checkpoints = [c for c in self.checkpoints if c.plan_id == normalized]
+        if len(plan_checkpoints) <= self.retention_limit:
+            return
+
+        keep_ids = {c.checkpoint_id for c in plan_checkpoints[-self.retention_limit :]}
+        self.checkpoints = [c for c in self.checkpoints if c.plan_id != normalized or c.checkpoint_id in keep_ids]

--- a/tests/test_coding_agent_execution_state_persistence.py
+++ b/tests/test_coding_agent_execution_state_persistence.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+import types
+
+
+BASE = pathlib.Path(__file__).parent.parent / "model-packs" / "coding-agent"
+DOMAIN = BASE / "domain-lib"
+CONTROLLERS = BASE / "controllers"
+
+
+def _load(name: str, path: pathlib.Path):
+    spec = importlib.util.spec_from_file_location(name, str(path))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _make_tier3_slice(node_id: str = "A"):
+    return {
+        "slice_id": f"{node_id}-slice",
+        "node_id": node_id,
+        "task_description": "Write README docs",
+        "allowed_tools": [],
+        "tier": 3,
+        "model_class": "slm",
+        "depends_on": [],
+        "plan": {
+            "plan_id": "plan-1",
+            "nodes": [
+                {"node_id": node_id, "description": "Write README docs", "depends_on": [], "tier_hint": 3},
+            ],
+            "created_at": "now",
+        },
+    }
+
+
+def test_execution_state_store_round_trip_and_retention():
+    store_mod = _load("coding_agent_execution_state_store_slice16", DOMAIN / "execution_state_store.py")
+
+    store = store_mod.ExecutionStateStore(retention_limit=2)
+    store.save_checkpoint("plan-1", {"retry_counts": {"A": 0}}, source="first")
+    store.save_checkpoint("plan-1", {"retry_counts": {"A": 1}}, source="second")
+    store.save_checkpoint("plan-1", {"retry_counts": {"A": 2}}, source="third")
+
+    checkpoints = store.list_checkpoints("plan-1")
+    assert len(checkpoints) == 2
+    assert checkpoints[-1].execution_context["retry_counts"] == {"A": 2}
+
+    restored = store_mod.ExecutionStateStore.from_dict(store.to_dict())
+    latest = restored.load_latest_checkpoint("plan-1")
+    assert latest is not None
+    assert latest.execution_context["retry_counts"] == {"A": 2}
+
+
+def test_runtime_tier3_checkpoint_persists_and_recovers(monkeypatch):
+    runtime = _load("coding_agent_runtime_slice16", CONTROLLERS / "runtime_adapters.py")
+
+    attempts = {"count": 0}
+    slm_mod = types.SimpleNamespace()
+    slm_mod.slm_available = lambda: True
+
+    def _flaky_call(system, user, model=None, max_tokens=None):
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise TimeoutError("temporary timeout")
+        return "SLM_OK"
+
+    slm_mod.call_slm = _flaky_call
+
+    lumina = types.ModuleType("lumina")
+    core = types.ModuleType("lumina.core")
+    system_log = types.ModuleType("lumina.system_log")
+    event_payload = types.ModuleType("lumina.system_log.event_payload")
+    log_bus = types.ModuleType("lumina.system_log.log_bus")
+
+    class _LogLevel:
+        AUDIT = "AUDIT"
+
+    def _create_event(**kwargs):
+        return kwargs
+
+    def _emit(event):
+        return None
+
+    event_payload.LogLevel = _LogLevel
+    event_payload.create_event = _create_event
+    log_bus.emit = _emit
+
+    core.slm = slm_mod
+    lumina.core = core
+    lumina.system_log = system_log
+
+    monkeypatch.setitem(sys.modules, "lumina", lumina)
+    monkeypatch.setitem(sys.modules, "lumina.core", core)
+    monkeypatch.setitem(sys.modules, "lumina.core.slm", slm_mod)
+    monkeypatch.setitem(sys.modules, "lumina.system_log", system_log)
+    monkeypatch.setitem(sys.modules, "lumina.system_log.event_payload", event_payload)
+    monkeypatch.setitem(sys.modules, "lumina.system_log.log_bus", log_bus)
+
+    task_spec = {"task_id": "job-16"}
+
+    state = {"turn_count": 0}
+    evidence = {
+        "job_scope_valid": True,
+        "micro_context": {"execution_tier": 3, "scope_valid": True},
+        "task_slice": _make_tier3_slice("A"),
+    }
+
+    state_after_first, first = runtime.domain_step(state, task_spec, evidence, {})
+
+    first_dispatch = first.get("dispatch_result")
+    assert first.get("action") == "dispatched"
+    assert first_dispatch and first_dispatch.get("reason") == "retry_scheduled"
+    assert "execution_state_store" in state_after_first
+
+    store_payload = state_after_first["execution_state_store"]
+    checkpoints = list(store_payload.get("checkpoints") or [])
+    assert checkpoints
+    assert checkpoints[-1]["execution_context"]["retry_counts"]["A"] == 1
+
+    state_after_second, second = runtime.domain_step(state_after_first, task_spec, evidence, {})
+
+    second_dispatch = second.get("dispatch_result")
+    assert second.get("action") == "dispatched"
+    assert second_dispatch and second_dispatch.get("dispatched") is True
+    assert second_dispatch.get("tier3_evidence", {}).get("status") == "success"
+
+    store_payload_second = state_after_second["execution_state_store"]
+    checkpoints_second = list(store_payload_second.get("checkpoints") or [])
+    assert len(checkpoints_second) >= 2
+    latest_context = checkpoints_second[-1]["execution_context"]
+    assert "A" in latest_context.get("completed_node_ids", [])
+    assert latest_context.get("retry_counts", {}).get("A") is None


### PR DESCRIPTION
﻿Slice 16: Execution State Persistence & Checkpoint Recovery

Summary:
- Adds in-pack execution checkpoint store and deterministic persistence for Tier-3 runs.
- Integrates restore/persist in runtime `domain_step` and adds `dispatch_to_tier_with_state` compatibility bridge.
- Includes unit tests for checkpoint retention and resume scenario.
- Adds roadmap doc and regenerated docs/MANIFEST.yaml.

Files changed (key):
- model-packs/coding-agent/domain-lib/execution_state_store.py
- model-packs/coding-agent/controllers/runtime_adapters.py
- model-packs/coding-agent/controllers/tier_dispatcher.py
- tests/test_coding_agent_execution_state_persistence.py
- docs/roadmap/slices/16-execution-state-persistence.md
- docs/MANIFEST.yaml

Tests run locally (focused):
- pytest tests/test_coding_agent_execution_state_persistence.py tests/test_coding_agent_tier3_gating_and_retry.py tests/test_coding_agent_tier_contracts.py tests/test_coding_agent_tier2_dispatch.py -> 15 passed
- pytest tests/test_system_log_integrity.py::TestManifestIntegrity::test_manifest_check_passes -> 1 passed

Notes for reviewers: See test tests/test_coding_agent_execution_state_persistence.py for expected behavior. Requesting review; I will address follow-ups promptly.
