### PR TITLE
Slice 18 — Orchestration Hardening and Determinism

### DIFF
--- a/docs/MANIFEST.yaml
+++ b/docs/MANIFEST.yaml
@@ -57,6 +57,13 @@ artifacts:
   status: planned
   last_updated: 2026-06-30
   sha256: ec092c525366f0794e929569e0bf60fe744c8ec5d93314a0ec1cb136d7bb786d
+- path: docs/roadmap/slices/18-orchestration-hardening-and-determinism.md
+  type: doc
+  section: 0
+  doc_version: 1.0.0
+  status: planned
+  last_updated: 2026-06-30
+  sha256: 4a43a503daeff3f36350fb06cc4b6ea5aa2397e1644aa3d0f00647dd3fbad569
 - path: docs/1-commands/README.md
   type: doc
   section: 1

--- a/docs/roadmap/slices/18-orchestration-hardening-and-determinism.md
+++ b/docs/roadmap/slices/18-orchestration-hardening-and-determinism.md
@@ -1,0 +1,25 @@
+---
+title: "Slice 18 — Orchestration Hardening and Determinism"
+slice: 18
+pack: model-packs/coding-agent/pack.yaml
+status: planned
+version: 0.1.0
+last_updated: 2026-06-30
+sha256: pending
+---
+
+Summary
+-------
+
+This slice hardens the Slice 17 orchestration path by making budget behavior deterministic, surfacing persistence failures explicitly, and preserving backward-compatible halt semantics for callers.
+
+Key points
+- Makes token budget checks slice-aware before dispatch using `TaskSlice.context_budget_tokens`.
+- Differentiates budget halt reasons (`slice_limit_reached`, `token_budget_exhausted`, `time_budget_exhausted`) and preserves compatibility via `halt_reason_compat`.
+- Consolidates halt resolution into one deterministic decision path.
+- Expands orchestration `evidence_timeline` entries to include full Tier-3 evidence payload.
+- Hardens runtime orchestration to return explicit failures when execution-state infrastructure is unavailable.
+- Adds regression tests for budget preflight, token accounting fallback, time-budget halts, evidence completeness, and invalid state-store handling.
+
+Notes
+- After adding or editing this file run `scripts/manifest-regenerate.ps1` to update `docs/MANIFEST.yaml`.

--- a/model-packs/coding-agent/controllers/orchestration_loop.py
+++ b/model-packs/coding-agent/controllers/orchestration_loop.py
@@ -77,6 +77,33 @@ def _extract_token_usage(dispatch_result: Dict[str, Any]) -> int:
                 return max(0, int(total))
             except Exception:
                 return 0
+        prompt_tokens = usage.get("prompt_tokens")
+        completion_tokens = usage.get("completion_tokens")
+        try:
+            return max(0, int(prompt_tokens or 0) + int(completion_tokens or 0))
+        except Exception:
+            return 0
+    try:
+        return max(0, int(dispatch_result.get("tokens_used", 0))) if isinstance(dispatch_result, dict) else 0
+    except Exception:
+        return 0
+
+
+def _slice_token_estimate(task_slice: Any) -> int:
+    try:
+        value = getattr(task_slice, "context_budget_tokens", 0)
+    except Exception:
+        value = 0
+    try:
+        return max(0, int(value or 0))
+    except Exception:
+        return 0
+
+
+def _compat_halt_reason(halt_reason: str) -> str:
+    if halt_reason in {"slice_limit_reached", "token_budget_exhausted", "time_budget_exhausted"}:
+        return "budget_exhausted"
+    return str(halt_reason)
     return 0
 
 
@@ -118,9 +145,13 @@ def execute_dag_until(
     executed_slice_ids: List[str] = []
     evidence_timeline: List[Dict[str, Any]] = []
     failed_node_id: str | None = None
-    halt_reason = "budget_exhausted"
+    halt_reason: str | None = None
 
-    while budget.can_execute_slice():
+    while True:
+        if not budget.can_execute_slice():
+            halt_reason = turn_budget.budget_exhaustion_reason(budget)
+            break
+
         ready = tier3_ready_scheduler.next_ready_slices(dag, slices, context)
         if not ready:
             all_nodes = {node.node_id for node in dag.nodes}
@@ -135,6 +166,11 @@ def execute_dag_until(
             break
 
         current = ready[0]
+        estimated_slice_tokens = _slice_token_estimate(current)
+        if not budget.can_execute_slice(next_slice_tokens=estimated_slice_tokens):
+            halt_reason = turn_budget.budget_exhaustion_reason(budget, next_slice_tokens=estimated_slice_tokens)
+            break
+
         payload = current.to_dict()
         payload["plan"] = dag.to_dict()
         payload["execution_context"] = context.to_dict()
@@ -148,25 +184,43 @@ def execute_dag_until(
 
         executed_slice_ids.append(str(current.slice_id))
         tier3_evidence = dispatch_result.get("tier3_evidence") if isinstance(dispatch_result, dict) else None
+        if not isinstance(tier3_evidence, dict):
+            tier3_evidence = {}
         evidence_timeline.append(
             {
                 "slice_id": str(current.slice_id),
                 "node_id": str(current.node_id),
                 "reason": str(dispatch_result.get("reason", "")) if isinstance(dispatch_result, dict) else "",
                 "dispatched": bool(dispatch_result.get("dispatched", False)) if isinstance(dispatch_result, dict) else False,
-                "status": str((tier3_evidence or {}).get("status", "")) if isinstance(tier3_evidence, dict) else "",
+                "status": str(tier3_evidence.get("status", "")),
+                "tier3_evidence": dict(tier3_evidence),
             }
         )
 
         if checkpoint_store is not None:
             try:
                 checkpoint_store.save_checkpoint(str(plan_id or "default"), context.to_dict(), source="orchestration_loop")
-            except Exception:
-                pass
+            except Exception as exc:
+                halt_reason = "checkpoint_persist_failed"
+                evidence_timeline.append(
+                    {
+                        "slice_id": str(current.slice_id),
+                        "node_id": str(current.node_id),
+                        "reason": "checkpoint_persist_failed",
+                        "dispatched": False,
+                        "status": "failed",
+                        "tier3_evidence": {
+                            "error_class": "checkpoint_persist_failed",
+                            "error_message": str(exc),
+                        },
+                    }
+                )
+                break
 
-        budget.record_slice(_extract_token_usage(dispatch_result if isinstance(dispatch_result, dict) else {}))
+        token_usage = _extract_token_usage(dispatch_result if isinstance(dispatch_result, dict) else {})
+        budget.record_slice(token_usage if token_usage > 0 else estimated_slice_tokens)
 
-        status = str((tier3_evidence or {}).get("status", "")) if isinstance(tier3_evidence, dict) else ""
+        status = str(tier3_evidence.get("status", ""))
         if status == "failed" or (
             isinstance(dispatch_result, dict)
             and dispatch_result.get("reason") == "tier3_execution_failed"
@@ -181,27 +235,22 @@ def execute_dag_until(
         ):
             halt_reason = "retry_scheduled"
             break
-    else:
-        all_nodes = {node.node_id for node in dag.nodes}
-        completed = set(context.completed_node_ids or [])
-        if all_nodes and all_nodes.issubset(completed):
-            halt_reason = "all_completed"
-        else:
-            halt_reason = turn_budget.budget_exhaustion_reason(budget)
 
-    if not budget.can_execute_slice() and halt_reason not in {"all_completed", "permanent_failure", "retry_scheduled", "no_ready_slices"}:
-        all_nodes = {node.node_id for node in dag.nodes}
-        completed = set(context.completed_node_ids or [])
-        if all_nodes and all_nodes.issubset(completed):
+    all_nodes = {node.node_id for node in dag.nodes}
+    completed = set(context.completed_node_ids or [])
+    if all_nodes and all_nodes.issubset(completed):
+        if halt_reason in {None, "no_ready_slices", "slice_limit_reached", "token_budget_exhausted", "time_budget_exhausted", "budget_available"}:
             halt_reason = "all_completed"
-        else:
-            halt_reason = turn_budget.budget_exhaustion_reason(budget)
+
+    if halt_reason is None:
+        halt_reason = turn_budget.budget_exhaustion_reason(budget)
 
     return orchestration_result.OrchestrationResult(
         executed_slice_ids=executed_slice_ids,
         completed_node_ids=list(context.completed_node_ids or []),
         failed_node_id=failed_node_id,
-        halt_reason=halt_reason,
+        halt_reason=str(halt_reason),
+        halt_reason_compat=_compat_halt_reason(str(halt_reason)),
         evidence_timeline=evidence_timeline,
         execution_context=context.to_dict(),
         budget=budget.to_dict(),

--- a/model-packs/coding-agent/controllers/runtime_adapters.py
+++ b/model-packs/coding-agent/controllers/runtime_adapters.py
@@ -203,15 +203,21 @@ def domain_step(
         try:
             _store, _contracts = _load_execution_modules()
             _loop, _turn_budget = _load_orchestration_modules()
-            state_store = _store.ExecutionStateStore.from_dict(new_state.get("execution_state_store") or {})
-        except Exception:
-            state_store = None
-            _contracts = None
-            _loop = None
-            _turn_budget = None
+        except Exception as exc:
+            return new_state, {
+                "action": "orchestration_failed",
+                "reason": "orchestration_modules_missing",
+                "detail": str(exc),
+            }
 
-        if _contracts is None or _loop is None or _turn_budget is None:
-            return new_state, {"action": "orchestration_failed", "reason": "orchestration_modules_missing"}
+        try:
+            state_store = _store.ExecutionStateStore.from_dict(new_state.get("execution_state_store") or {})
+        except Exception as exc:
+            return new_state, {
+                "action": "orchestration_failed",
+                "reason": "execution_state_store_unavailable",
+                "detail": str(exc),
+            }
 
         plan_payload = evidence.get("plan") if isinstance(evidence.get("plan"), dict) else None
         slices_payload = evidence.get("task_slices") if isinstance(evidence.get("task_slices"), list) else []
@@ -226,11 +232,14 @@ def domain_step(
             return new_state, {"action": "orchestration_failed", "reason": "plan_or_slices_missing"}
 
         plan_id = str(plan_payload.get("plan_id") or task_spec.get("task_id") or "default")
-        latest = state_store.load_latest_checkpoint(plan_id) if state_store is not None else None
+        latest = state_store.load_latest_checkpoint(plan_id)
+        explicit_context_payload = evidence.get("execution_context") if isinstance(evidence.get("execution_context"), dict) else None
+        if explicit_context_payload is None and isinstance(task_slice_payload.get("execution_context"), dict):
+            explicit_context_payload = dict(task_slice_payload.get("execution_context") or {})
         if latest is not None:
             restored_context = _contracts.ExecutionContext.from_dict(latest.execution_context)
         else:
-            restored_context = _contracts.ExecutionContext.from_dict(evidence.get("execution_context") or {})
+            restored_context = _contracts.ExecutionContext.from_dict(explicit_context_payload or {})
 
         budget = _turn_budget.TurnBudget.from_params(params)
         orchestration = _loop.execute_dag_until(
@@ -243,8 +252,14 @@ def domain_step(
         )
 
         orchestration_result = orchestration.to_dict() if hasattr(orchestration, "to_dict") else dict(orchestration or {})
-        if state_store is not None:
-            new_state["execution_state_store"] = state_store.to_dict()
+        if orchestration_result.get("halt_reason") == "checkpoint_persist_failed":
+            return new_state, {
+                "action": "orchestration_failed",
+                "reason": "checkpoint_persist_failed",
+                "dispatch_result": orchestration_result,
+            }
+
+        new_state["execution_state_store"] = state_store.to_dict()
 
         return new_state, {"action": "orchestrated", "dispatch_result": orchestration_result}
 

--- a/model-packs/coding-agent/domain-lib/orchestration_result.py
+++ b/model-packs/coding-agent/domain-lib/orchestration_result.py
@@ -10,6 +10,7 @@ class OrchestrationResult:
     completed_node_ids: List[str] = field(default_factory=list)
     failed_node_id: str | None = None
     halt_reason: str = "budget_exhausted"
+    halt_reason_compat: str = "budget_exhausted"
     evidence_timeline: List[Dict[str, Any]] = field(default_factory=list)
     execution_context: Dict[str, Any] = field(default_factory=dict)
     budget: Dict[str, Any] = field(default_factory=dict)
@@ -20,6 +21,7 @@ class OrchestrationResult:
             "completed_node_ids": [str(value) for value in list(self.completed_node_ids or [])],
             "failed_node_id": None if self.failed_node_id is None else str(self.failed_node_id),
             "halt_reason": str(self.halt_reason),
+            "halt_reason_compat": str(self.halt_reason_compat),
             "evidence_timeline": [dict(value or {}) for value in list(self.evidence_timeline or [])],
             "execution_context": dict(self.execution_context or {}),
             "budget": dict(self.budget or {}),
@@ -34,6 +36,7 @@ class OrchestrationResult:
             completed_node_ids=[str(value) for value in list(payload.get("completed_node_ids") or [])],
             failed_node_id=None if failed_node in (None, "") else str(failed_node),
             halt_reason=str(payload.get("halt_reason", "budget_exhausted")),
+            halt_reason_compat=str(payload.get("halt_reason_compat", payload.get("halt_reason", "budget_exhausted"))),
             evidence_timeline=[dict(value or {}) for value in list(payload.get("evidence_timeline") or [])],
             execution_context=dict(payload.get("execution_context") or {}),
             budget=dict(payload.get("budget") or {}),

--- a/model-packs/coding-agent/domain-lib/turn_budget.py
+++ b/model-packs/coding-agent/domain-lib/turn_budget.py
@@ -58,10 +58,13 @@ class TurnBudget:
         elapsed = max(0.0, now - float(self.started_at_epoch))
         return max(0.0, float(self.max_time_seconds) - elapsed)
 
-    def can_execute_slice(self, now_epoch: float | None = None) -> bool:
+    def can_execute_slice(self, now_epoch: float | None = None, next_slice_tokens: int = 0) -> bool:
         if self.executed_slices >= self.max_slices_per_turn:
             return False
         if self.max_tokens > 0 and self.consumed_tokens >= self.max_tokens:
+            return False
+        next_tokens = max(0, int(next_slice_tokens or 0))
+        if self.max_tokens > 0 and next_tokens > 0 and (self.consumed_tokens + next_tokens) > self.max_tokens:
             return False
         remaining = self.time_remaining(now_epoch)
         if remaining is not None and remaining <= 0:
@@ -73,12 +76,23 @@ class TurnBudget:
         self.consumed_tokens = int(self.consumed_tokens) + max(0, int(token_count or 0))
 
 
-def budget_exhaustion_reason(turn_budget: TurnBudget, now_epoch: float | None = None) -> str:
+def budget_exhaustion_reason(
+    turn_budget: TurnBudget,
+    now_epoch: float | None = None,
+    next_slice_tokens: int = 0,
+) -> str:
     if turn_budget.executed_slices >= turn_budget.max_slices_per_turn:
-        return "budget_exhausted"
+        return "slice_limit_reached"
+    projected_tokens = max(0, int(next_slice_tokens or 0))
+    if (
+        turn_budget.max_tokens > 0
+        and projected_tokens > 0
+        and (turn_budget.consumed_tokens + projected_tokens) > turn_budget.max_tokens
+    ):
+        return "token_budget_exhausted"
     if turn_budget.max_tokens > 0 and turn_budget.consumed_tokens >= turn_budget.max_tokens:
-        return "budget_exhausted"
+        return "token_budget_exhausted"
     remaining = turn_budget.time_remaining(now_epoch)
     if remaining is not None and remaining <= 0:
-        return "budget_exhausted"
+        return "time_budget_exhausted"
     return "budget_available"

--- a/tests/test_coding_agent_execution_state_persistence.py
+++ b/tests/test_coding_agent_execution_state_persistence.py
@@ -135,3 +135,70 @@ def test_runtime_tier3_checkpoint_persists_and_recovers(monkeypatch):
     latest_context = checkpoints_second[-1]["execution_context"]
     assert "A" in latest_context.get("completed_node_ids", [])
     assert latest_context.get("retry_counts", {}).get("A") is None
+
+
+def test_runtime_orchestration_fails_when_execution_state_store_invalid(monkeypatch):
+    runtime = _load("coding_agent_runtime_slice18", CONTROLLERS / "runtime_adapters.py")
+
+    slm_mod = types.SimpleNamespace()
+    slm_mod.slm_available = lambda: True
+    slm_mod.call_slm = lambda system, user, model=None, max_tokens=None: "SLM_OK"
+
+    lumina = types.ModuleType("lumina")
+    core = types.ModuleType("lumina.core")
+    system_log = types.ModuleType("lumina.system_log")
+    event_payload = types.ModuleType("lumina.system_log.event_payload")
+    log_bus = types.ModuleType("lumina.system_log.log_bus")
+
+    class _LogLevel:
+        AUDIT = "AUDIT"
+
+    def _create_event(**kwargs):
+        return kwargs
+
+    def _emit(event):
+        return None
+
+    event_payload.LogLevel = _LogLevel
+    event_payload.create_event = _create_event
+    log_bus.emit = _emit
+
+    core.slm = slm_mod
+    lumina.core = core
+    lumina.system_log = system_log
+
+    monkeypatch.setitem(sys.modules, "lumina", lumina)
+    monkeypatch.setitem(sys.modules, "lumina.core", core)
+    monkeypatch.setitem(sys.modules, "lumina.core.slm", slm_mod)
+    monkeypatch.setitem(sys.modules, "lumina.system_log", system_log)
+    monkeypatch.setitem(sys.modules, "lumina.system_log.event_payload", event_payload)
+    monkeypatch.setitem(sys.modules, "lumina.system_log.log_bus", log_bus)
+
+    evidence = {
+        "job_scope_valid": True,
+        "use_orchestration_loop": True,
+        "plan": {
+            "plan_id": "plan-18",
+            "nodes": [{"node_id": "A", "description": "Do A", "depends_on": [], "tier_hint": 3}],
+            "created_at": "now",
+        },
+        "task_slices": [
+            {
+                "slice_id": "A-slice",
+                "node_id": "A",
+                "task_description": "Do A",
+                "allowed_tools": [],
+                "context_budget_tokens": 5,
+                "tier": 3,
+                "model_class": "slm",
+                "depends_on": [],
+            }
+        ],
+    }
+
+    state = {"turn_count": 0, "execution_state_store": {"retention_limit": "bad"}}
+    next_state, out = runtime.domain_step(state, {"task_id": "plan-18"}, evidence, {"max_slices_per_turn": 1})
+
+    assert next_state.get("turn_count") == 1
+    assert out.get("action") == "orchestration_failed"
+    assert out.get("reason") == "execution_state_store_unavailable"

--- a/tests/test_coding_agent_orchestration_loop.py
+++ b/tests/test_coding_agent_orchestration_loop.py
@@ -4,6 +4,7 @@ import importlib.util
 import pathlib
 import sys
 import types
+import time
 
 
 BASE = pathlib.Path(__file__).parent.parent / "model-packs" / "coding-agent"
@@ -77,12 +78,13 @@ def _plan_dict(nodes):
     }
 
 
-def _slice(node_id: str, depends_on=None):
+def _slice(node_id: str, depends_on=None, context_budget_tokens: int = 8):
     return {
         "slice_id": f"{node_id}-slice",
         "node_id": node_id,
         "task_description": f"Execute node {node_id}",
         "allowed_tools": [],
+        "context_budget_tokens": context_budget_tokens,
         "tier": 3,
         "model_class": "slm",
         "depends_on": list(depends_on or []),
@@ -152,7 +154,8 @@ def test_orchestration_loop_respects_slice_budget(monkeypatch):
 
     result = orchestration_loop.execute_dag_until(plan, {}, slices, budget)
 
-    assert result.halt_reason == "budget_exhausted"
+    assert result.halt_reason == "slice_limit_reached"
+    assert result.halt_reason_compat == "budget_exhausted"
     assert result.executed_slice_ids == ["A-slice"]
     assert result.completed_node_ids == ["A"]
 
@@ -176,7 +179,8 @@ def test_runtime_domain_step_orchestrates_and_resumes(monkeypatch):
     assert out_1.get("action") == "orchestrated"
     first_result = out_1.get("dispatch_result") or {}
     assert first_result.get("executed_slice_ids") == ["A-slice"]
-    assert first_result.get("halt_reason") == "budget_exhausted"
+    assert first_result.get("halt_reason") == "slice_limit_reached"
+    assert first_result.get("halt_reason_compat") == "budget_exhausted"
     assert "execution_state_store" in state_1
 
     state_2, out_2 = runtime.domain_step(state_1, {"task_id": "plan-17"}, evidence, params)
@@ -185,3 +189,66 @@ def test_runtime_domain_step_orchestrates_and_resumes(monkeypatch):
     second_result = out_2.get("dispatch_result") or {}
     assert second_result.get("executed_slice_ids") == ["B-slice"]
     assert second_result.get("halt_reason") == "all_completed"
+
+
+def test_orchestration_loop_blocks_preflight_when_token_budget_too_small(monkeypatch):
+    _install_lumina_slm(monkeypatch, lambda system, user, model=None, max_tokens=None: "SLM_OK")
+
+    plan = _plan_dict([("A", "root", [])])
+    slices = [_slice("A", context_budget_tokens=40)]
+    budget = turn_budget.TurnBudget(max_tokens=16, max_slices_per_turn=5)
+
+    result = orchestration_loop.execute_dag_until(plan, {}, slices, budget)
+
+    assert result.executed_slice_ids == []
+    assert result.halt_reason == "token_budget_exhausted"
+    assert result.halt_reason_compat == "budget_exhausted"
+
+
+def test_orchestration_loop_records_estimated_tokens_when_usage_missing(monkeypatch):
+    _install_lumina_slm(monkeypatch, lambda system, user, model=None, max_tokens=None: "SLM_OK")
+
+    plan = _plan_dict([("A", "root", []), ("B", "next", ["A"])])
+    slices = [_slice("A", context_budget_tokens=9), _slice("B", ["A"], context_budget_tokens=11)]
+    budget = turn_budget.TurnBudget(max_tokens=30, max_slices_per_turn=5)
+
+    result = orchestration_loop.execute_dag_until(plan, {}, slices, budget)
+
+    assert result.halt_reason == "all_completed"
+    assert result.budget.get("consumed_tokens") == 20
+
+
+def test_orchestration_loop_halts_when_time_budget_exhausted(monkeypatch):
+    _install_lumina_slm(monkeypatch, lambda system, user, model=None, max_tokens=None: "SLM_OK")
+
+    plan = _plan_dict([("A", "root", [])])
+    slices = [_slice("A", context_budget_tokens=5)]
+    budget = turn_budget.TurnBudget(
+        max_slices_per_turn=5,
+        max_time_seconds=1.0,
+        started_at_epoch=time.time() - 10.0,
+    )
+
+    result = orchestration_loop.execute_dag_until(plan, {}, slices, budget)
+
+    assert result.executed_slice_ids == []
+    assert result.halt_reason == "time_budget_exhausted"
+    assert result.halt_reason_compat == "budget_exhausted"
+
+
+def test_orchestration_loop_evidence_timeline_carries_tier3_payload(monkeypatch):
+    _install_lumina_slm(monkeypatch, lambda system, user, model=None, max_tokens=None: "SLM_OK")
+
+    plan = _plan_dict([("A", "root", [])])
+    slices = [_slice("A", context_budget_tokens=5)]
+    budget = turn_budget.TurnBudget(max_slices_per_turn=5)
+
+    result = orchestration_loop.execute_dag_until(plan, {}, slices, budget)
+
+    assert result.evidence_timeline
+    evidence = result.evidence_timeline[0].get("tier3_evidence") or {}
+    assert evidence.get("attempt_count") == 0
+    assert "error_class" in evidence
+    assert "error_message" in evidence
+    assert "allowed_tools" in evidence
+    assert "denied_tools" in evidence


### PR DESCRIPTION
## Summary
- harden orchestration budget semantics with slice-aware token preflight
- make halt resolution deterministic and introduce explicit budget reason taxonomy
- preserve backward compatibility with `halt_reason_compat=budget_exhausted`
- enrich `evidence_timeline` with full Tier-3 evidence payload
- make orchestration runtime fail explicitly on execution-state infrastructure/persistence failures
- add Slice 18 roadmap doc and regenerate manifest hashes

## Implementation Details
- `TurnBudget.can_execute_slice(...)` now supports projected token checks
- `budget_exhaustion_reason(...)` now returns:
  - `slice_limit_reached`
  - `token_budget_exhausted`
  - `time_budget_exhausted`
- `OrchestrationResult` now includes `halt_reason_compat` for caller compatibility
- `execute_dag_until(...)` now uses a single halt decision path and fallback token accounting from `TaskSlice.context_budget_tokens`

## Backward Compatibility
- external orchestration envelope is unchanged: `{"action": "orchestrated", "dispatch_result": ...}`
- compatibility field maps new budget reasons back to `budget_exhausted`

## Validation
- `pytest -q tests/test_coding_agent_orchestration_loop.py tests/test_coding_agent_execution_state_persistence.py tests/test_coding_agent_tier3_gating_and_retry.py`
- `pytest -q tests/test_schema_versioning.py tests/test_manifest_integrity.py`

## Release Note
This change introduces a more precise halt reason taxonomy for orchestration budget stops while maintaining compatibility through `halt_reason_compat`.
