### PR TITLE
feat(coding-agent): Slice 22 System Pack Activation Gate

### DIFF
--- a/docs/MANIFEST.yaml
+++ b/docs/MANIFEST.yaml
@@ -1,5 +1,5 @@
 ﻿schema_version: 1.0.0
-last_updated: 2026-06-30
+last_updated: 2026-07-01
 artifacts:
 - path: docs/5-standards/manifest-regen-policy.md
   type: doc
@@ -1852,7 +1852,7 @@ artifacts:
   doc_version: 1.0.0
   status: active
   last_updated: 2026-06-18
-  sha256: 4d2fca6c3ee051f86e344fc4ae5aecea63a459cb54c6ee9c0d01f221cf1cd85a
+  sha256: 19a5b7d07060c31b8c582b6c636fe6fd312e4e0ca2cda7d28ac3c3fca75570f7
 - path: docs/roadmap/slices/01-framework-boundary.md
   type: doc
   doc_version: 1.0.0

--- a/docs/MANIFEST.yaml
+++ b/docs/MANIFEST.yaml
@@ -85,6 +85,13 @@ artifacts:
   status: planned
   last_updated: 2026-06-30
   sha256: 3d2552a59258ea91368765c8c8b05bf1491ac180b511285d3e53067372285b2e
+- path: docs/roadmap/slices/22-system-pack-activation-gate.md
+  type: doc
+  section: 0
+  doc_version: 1.0.0
+  status: proposed
+  last_updated: 2026-07-01
+  sha256: 1e9c85b1b71359e067762eff89d12e59eb14294ad1010017991726d7b1219a14
 - path: docs/1-commands/README.md
   type: doc
   section: 1

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -47,6 +47,7 @@ under `docs/roadmap/slices/` and delivered as a focused PR.
 | [19](slices/19-execution-telemetry-and-trace-export.md) | Execution Telemetry and Trace Export | Delivered |
 | [20](slices/20-tiered-model-and-api-key-routing.md) | Tiered Model and API Key Routing | Delivered |
 | [21](slices/21-framework-boundary-reconciliation.md) | Framework Boundary Reconciliation | Planned |
+| [22](slices/22-system-pack-activation-gate.md) | System Pack Approval / Activation Gate | Proposed |
 
 ---
 

--- a/docs/roadmap/slices/22-system-pack-activation-gate.md
+++ b/docs/roadmap/slices/22-system-pack-activation-gate.md
@@ -2,6 +2,8 @@
 title: Slice 22 — System Pack Approval / Activation Gate
 slice: 22
 status: proposed
+version: 1.0.0
+last_updated: 2026-07-01
 ---
 
 Summary

--- a/docs/roadmap/slices/22-system-pack-activation-gate.md
+++ b/docs/roadmap/slices/22-system-pack-activation-gate.md
@@ -1,0 +1,42 @@
+---
+title: Slice 22 — System Pack Approval / Activation Gate
+slice: 22
+status: proposed
+---
+
+Summary
+-------
+
+Slice 22 adds an explicit activation/approval gate: the Coding Agent may
+request activation of validated patches (e.g. `activation_request`), but
+the final activation must be authorized by the System Pack. This preserves
+the framework invariant that System Pack is the sole activation authority
+and prevents the Coding Agent from self-activating changes or holding
+deployment credentials.
+
+Design
+------
+
+- Introduce a minimal `activation_gate` module that exposes `validate_activation(evidence)`.
+- When a turn includes `activation_request: true`, runtime adapters must
+  require `system_approval: { approved: true, issuer: 'system_pack' }`.
+- If approval is missing, the runtime returns `action: awaiting_system_approval`
+  and the request is halted for human or System Pack approval.
+
+Acceptance criteria
+-------------------
+
+- The runtime returns `awaiting_system_approval` when an activation is
+  requested without System Pack approval.
+- When `system_approval` is present and valid, activation flow proceeds
+  (the runtime may still stage the patch for review but should surface
+  `approved: true` in the dispatch response).
+- Unit tests cover both blocked and approved activation flows.
+
+Notes
+-----
+
+- This slice is intentionally minimal: it enforces a record-level approval
+  check and does not implement a signing or cryptographic workflow.
+- For deployments that require stronger attestation, extend the approval
+  object to include signatures and validation routines handled by System Pack.

--- a/model-packs/coding-agent/controllers/runtime_adapters.py
+++ b/model-packs/coding-agent/controllers/runtime_adapters.py
@@ -190,12 +190,36 @@ def domain_step(
     if patch_generated and tests_passed is True:
         new_state["pending_validation"] = False
         new_state["scoped_jobs_completed"] = int(new_state.get("scoped_jobs_completed", 0)) + 1
+        # If the caller requested immediate activation, require System Pack approval.
+        try:
+            from model_packs.coding_agent.domain_lib import activation_gate as _ag
+        except Exception:
+            _ag = None
+
+        if isinstance(evidence, dict) and evidence.get("activation_request"):
+            approved = False
+            if _ag is not None:
+                try:
+                    approved = _ag.validate_activation(evidence)
+                except Exception:
+                    approved = False
+
+            if not approved:
+                return new_state, {
+                    "tier": "ok",
+                    "action": "awaiting_system_approval",
+                    "frustration": False,
+                    "escalation_eligible": True,
+                    "reason": "activation_requires_system_approval",
+                }
+
         return new_state, {
             "tier": "ok",
             "action": "stage_patch_for_review",
             "frustration": False,
             "escalation_eligible": False,
             "reason": "validated_patch",
+            "approved": True if isinstance(evidence, dict) and evidence.get("activation_request") and _ag is not None and _ag.validate_activation(evidence) else False,
         }
 
     # Prioritise orchestration loop when requested with plan + task_slices.

--- a/model-packs/coding-agent/domain-lib/activation_gate.py
+++ b/model-packs/coding-agent/domain-lib/activation_gate.py
@@ -1,0 +1,32 @@
+"""System Pack activation/approval gate for Coding Agent slices.
+
+This module provides a minimal policy: when a slice requests activation
+of a validated patch (`activation_request`), the operation must include a
+`system_approval` object issued by the System Pack. The approval object
+is expected to be a dict with `approved: True` and `issuer: 'system_pack'`.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def requires_system_approval(evidence: Dict[str, Any]) -> bool:
+    if not isinstance(evidence, dict):
+        return False
+    return bool(evidence.get("activation_request"))
+
+
+def is_system_approved(evidence: Dict[str, Any]) -> bool:
+    if not isinstance(evidence, dict):
+        return False
+    ap = evidence.get("system_approval")
+    if not isinstance(ap, dict):
+        return False
+    return bool(ap.get("approved") is True and ap.get("issuer") == "system_pack")
+
+
+def validate_activation(evidence: Dict[str, Any]) -> bool:
+    """Return True if either activation not requested or approval present."""
+    if not requires_system_approval(evidence):
+        return True
+    return is_system_approved(evidence)

--- a/model_packs/coding_agent/domain_lib/activation_gate.py
+++ b/model_packs/coding_agent/domain_lib/activation_gate.py
@@ -1,0 +1,28 @@
+"""System Pack activation/approval gate for Coding Agent slices. (compat path)
+
+This mirrors the implementation under model-packs for CI and import compatibility.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def requires_system_approval(evidence: Dict[str, Any]) -> bool:
+    if not isinstance(evidence, dict):
+        return False
+    return bool(evidence.get("activation_request"))
+
+
+def is_system_approved(evidence: Dict[str, Any]) -> bool:
+    if not isinstance(evidence, dict):
+        return False
+    ap = evidence.get("system_approval")
+    if not isinstance(ap, dict):
+        return False
+    return bool(ap.get("approved") is True and ap.get("issuer") == "system_pack")
+
+
+def validate_activation(evidence: Dict[str, Any]) -> bool:
+    if not requires_system_approval(evidence):
+        return True
+    return is_system_approved(evidence)

--- a/tests/test_coding_agent_activation_gate.py
+++ b/tests/test_coding_agent_activation_gate.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+
+
+BASE = pathlib.Path(__file__).parent.parent / "model-packs" / "coding-agent"
+CONTROLLERS = BASE / "controllers"
+
+
+def _load(name: str, path: pathlib.Path):
+    spec = importlib.util.spec_from_file_location(name, str(path))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_activation_blocks_without_system_approval():
+    runtime = _load("coding_agent_runtime_slice22", CONTROLLERS / "runtime_adapters.py")
+
+    state = {"turn_count": 0}
+    task_spec = {"task_id": "job-22"}
+    evidence = {
+        "job_scope_valid": True,
+        "patch_generated": True,
+        "tests_passed": True,
+        "activation_request": True,
+    }
+
+    next_state, out = runtime.domain_step(state, task_spec, evidence, {})
+
+    assert next_state.get("turn_count") == 1
+    assert out.get("action") == "awaiting_system_approval"
+    assert out.get("reason") == "activation_requires_system_approval"
+
+
+def test_activation_allows_with_system_approval():
+    runtime = _load("coding_agent_runtime_slice22b", CONTROLLERS / "runtime_adapters.py")
+
+    state = {"turn_count": 0}
+    task_spec = {"task_id": "job-22b"}
+    evidence = {
+        "job_scope_valid": True,
+        "patch_generated": True,
+        "tests_passed": True,
+        "activation_request": True,
+        "system_approval": {"approved": True, "issuer": "system_pack"},
+    }
+
+    next_state, out = runtime.domain_step(state, task_spec, evidence, {})
+
+    assert next_state.get("turn_count") == 1
+    assert out.get("action") == "stage_patch_for_review"
+    assert out.get("approved") is True


### PR DESCRIPTION
Adds Slice 22: System Pack Approval / Activation Gate.

Summary:
- Introduces ctivation_gate module to enforce that any ctivation_request requires a system_approval object issued by the System Pack.
- Integrates approval check into untime_adapters.domain_step to return ction: awaiting_system_approval when an activation is requested without valid approval.
- Adds unit tests covering blocked and approved activation flows.
- Updates roadmap docs and regenerates docs/MANIFEST.yaml.

Files of interest:
- model-packs/coding-agent/domain-lib/activation_gate.py
- model_packs/coding_agent/domain_lib/activation_gate.py
- model-packs/coding-agent/controllers/runtime_adapters.py
- tests/test_coding_agent_activation_gate.py
- docs/roadmap/slices/22-system-pack-activation-gate.md
- docs/MANIFEST.yaml

Checklist for reviewers:
- [ ] Confirm runtime behavior for ctivation_request and system_approval semantics.
- [ ] Validate tests are appropriate and sufficiently cover the gate.
- [ ] Confirm docs/manifest update is correct and governance-conformant.

If acceptable, merge into main after approvals. If you want a follow-up slice to implement cryptographic attestation or System Pack workflows, I can add that as a separate change.