### PR TITLE
feat(system): slice 24 - system-led evidence commit and teardown confirmation

### DIFF
--- a/docs/MANIFEST.yaml
+++ b/docs/MANIFEST.yaml
@@ -1,5 +1,5 @@
 ﻿schema_version: 1.0.0
-last_updated: 2026-07-01
+last_updated: 2026-07-07
 artifacts:
 - path: docs/5-standards/manifest-regen-policy.md
   type: doc

--- a/docs/MANIFEST.yaml
+++ b/docs/MANIFEST.yaml
@@ -1229,7 +1229,7 @@ artifacts:
   doc_version: 1.0.0
   status: active
   last_updated: 2026-04-04
-  sha256: 4561fd031d64e27b2405294c0d068d5b7246130383453ea431db5c6b20b60f24
+  sha256: c0a5645b08a577f59f2efc36e302757d17ad6d0a5dcf48a8cfea43d4999affb0
 - path: model-packs/system/cfg/ui-config.yaml
   type: config
   doc_version: 1.0.0

--- a/docs/MANIFEST.yaml
+++ b/docs/MANIFEST.yaml
@@ -99,6 +99,13 @@ artifacts:
   status: proposed
   last_updated: 2026-07-01
   sha256: 28db68b1cf482ae5170b00f4bfae2eabf5c87a10f48dcaa6ad1781b9072a2747
+ - path: docs/roadmap/slices/24-system-led-evidence-commit-and-teardown-confirmation.md
+   type: doc
+   section: 0
+   doc_version: 1.0.0
+   status: proposed
+   last_updated: 2026-07-07
+   sha256: 007de360b543ee181b56e776ea80404399f48ef4696bc11ab88ed4981357f216
 - path: docs/1-commands/README.md
   type: doc
   section: 1

--- a/docs/MANIFEST.yaml
+++ b/docs/MANIFEST.yaml
@@ -85,20 +85,27 @@ artifacts:
   status: planned
   last_updated: 2026-06-30
   sha256: 3d2552a59258ea91368765c8c8b05bf1491ac180b511285d3e53067372285b2e
- - path: docs/roadmap/slices/23-evidence-harvest-and-teardown.md
-   type: doc
-   section: 0
-   doc_version: 1.0.0
-   status: proposed
-   last_updated: 2026-07-01
-   sha256: 28db68b1cf482ae5170b00f4bfae2eabf5c87a10f48dcaa6ad1781b9072a2747
- - path: docs/roadmap/slices/24-system-led-evidence-commit-and-teardown-confirmation.md
-   type: doc
-   section: 0
-   doc_version: 1.0.0
-   status: proposed
-   last_updated: 2026-07-07
-   sha256: pending
+- path: docs/roadmap/slices/22-system-pack-activation-gate.md
+  type: doc
+  section: 0
+  doc_version: 1.0.0
+  status: proposed
+  last_updated: 2026-07-01
+  sha256: 1e9c85b1b71359e067762eff89d12e59eb14294ad1010017991726d7b1219a14
+- path: docs/roadmap/slices/23-evidence-harvest-and-teardown.md
+  type: doc
+  section: 0
+  doc_version: 1.0.0
+  status: proposed
+  last_updated: 2026-07-01
+  sha256: 28db68b1cf482ae5170b00f4bfae2eabf5c87a10f48dcaa6ad1781b9072a2747
+- path: docs/roadmap/slices/24-system-led-evidence-commit-and-teardown-confirmation.md
+  type: doc
+  section: 0
+  doc_version: 1.0.0
+  status: proposed
+  last_updated: 2026-07-07
+  sha256: 007de360b543ee181b56e776ea80404399f48ef4696bc11ab88ed4981357f216
 - path: docs/1-commands/README.md
   type: doc
   section: 1

--- a/docs/MANIFEST.yaml
+++ b/docs/MANIFEST.yaml
@@ -1,5 +1,5 @@
 ﻿schema_version: 1.0.0
-last_updated: 2026-07-07
+last_updated: 2026-07-11
 artifacts:
 - path: docs/5-standards/manifest-regen-policy.md
   type: doc
@@ -105,7 +105,7 @@ artifacts:
   doc_version: 1.0.0
   status: proposed
   last_updated: 2026-07-07
-  sha256: 007de360b543ee181b56e776ea80404399f48ef4696bc11ab88ed4981357f216
+  sha256: 982ff274470e4d58d6e0f81413e941c7c116f9bf3244ace91f57c239bfb63819
 - path: docs/1-commands/README.md
   type: doc
   section: 1

--- a/docs/MANIFEST.yaml
+++ b/docs/MANIFEST.yaml
@@ -85,27 +85,20 @@ artifacts:
   status: planned
   last_updated: 2026-06-30
   sha256: 3d2552a59258ea91368765c8c8b05bf1491ac180b511285d3e53067372285b2e
-- path: docs/roadmap/slices/22-system-pack-activation-gate.md
-  type: doc
-  section: 0
-  doc_version: 1.0.0
-  status: proposed
-  last_updated: 2026-07-01
-  sha256: 1e9c85b1b71359e067762eff89d12e59eb14294ad1010017991726d7b1219a14
-- path: docs/roadmap/slices/23-evidence-harvest-and-teardown.md
-  type: doc
-  section: 0
-  doc_version: 1.0.0
-  status: proposed
-  last_updated: 2026-07-01
-  sha256: 28db68b1cf482ae5170b00f4bfae2eabf5c87a10f48dcaa6ad1781b9072a2747
+ - path: docs/roadmap/slices/23-evidence-harvest-and-teardown.md
+   type: doc
+   section: 0
+   doc_version: 1.0.0
+   status: proposed
+   last_updated: 2026-07-01
+   sha256: 28db68b1cf482ae5170b00f4bfae2eabf5c87a10f48dcaa6ad1781b9072a2747
  - path: docs/roadmap/slices/24-system-led-evidence-commit-and-teardown-confirmation.md
    type: doc
    section: 0
    doc_version: 1.0.0
    status: proposed
    last_updated: 2026-07-07
-   sha256: 007de360b543ee181b56e776ea80404399f48ef4696bc11ab88ed4981357f216
+   sha256: pending
 - path: docs/1-commands/README.md
   type: doc
   section: 1

--- a/docs/roadmap/slices/24-system-led-evidence-commit-and-teardown-confirmation.md
+++ b/docs/roadmap/slices/24-system-led-evidence-commit-and-teardown-confirmation.md
@@ -1,0 +1,34 @@
+---
+title: "Slice 24 — System-Led Evidence Commit and Teardown Confirmation"
+version: 0.1.0
+last_updated: 2026-07-07
+---
+
+This slice implements the System Pack side of the evidence lifecycle after
+Coding Agent orchestration emits `evidence_commit` and `teardown_result`.
+
+Goals:
+- Commit Coding Agent evidence as System-led `CommitmentRecord` entries.
+- Confirm teardown on success and escalate cleanup failures deterministically.
+- Preserve governance invariants: Coding Agent still cannot self-commit or self-activate.
+
+Implemented:
+- `model-packs/system/controllers/evidence_commit_teardown.py`
+  - `commit_evidence_and_confirm_teardown(payload)`
+  - Transaction progression using `state_transaction_adapter`
+    (`PROPOSED -> VALIDATED -> COMMITTED -> FINALIZED`).
+  - Ledger writes for:
+    - `evidence_commit`
+    - `teardown_confirmation` on success
+    - `cleanup_escalated` on teardown failure
+- `tests/test_system_evidence_commit_and_teardown.py`
+  - Success path
+  - Teardown failure escalation path
+  - Idempotency for finalized transactions
+  - Invalid payload guard
+
+Notes:
+- Lifecycle markers emitted by this slice:
+  `HarvestingEvidence -> EvidenceCommitted -> TearingDown -> TeardownConfirmed`
+  with failure markers `TeardownFailed -> CleanupEscalated`.
+- Orchestration envelopes remain additive and backward compatible.

--- a/docs/roadmap/slices/24-system-led-evidence-commit-and-teardown-confirmation.md
+++ b/docs/roadmap/slices/24-system-led-evidence-commit-and-teardown-confirmation.md
@@ -29,6 +29,7 @@ Implemented:
 
 Notes:
 - Lifecycle markers emitted by this slice:
-  `HarvestingEvidence -> EvidenceCommitted -> TearingDown -> TeardownConfirmed`
+  `EvidenceCommitted -> TearingDown -> TeardownConfirmed`
   with failure markers `TeardownFailed -> CleanupEscalated`.
+- `HarvestingEvidence` is tracked in transaction metadata before commit.
 - Orchestration envelopes remain additive and backward compatible.

--- a/model-packs/system/cfg/runtime-config.yaml
+++ b/model-packs/system/cfg/runtime-config.yaml
@@ -180,6 +180,10 @@ adapters:
       module_path: model-packs/system/controllers/tool_adapters.py
       callable: verify_no_disclosure
 
+    commit_evidence_and_confirm_teardown:
+      module_path: model-packs/system/controllers/evidence_commit_teardown.py
+      callable: commit_evidence_and_confirm_teardown
+
 # ── Resource Monitor Daemon ───────────────────────────────────
 daemon:
   enabled: true

--- a/model-packs/system/controllers/evidence_commit_teardown.py
+++ b/model-packs/system/controllers/evidence_commit_teardown.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from lumina.core.state_machine import StateTransaction, TransactionState
+from lumina.system_log.admin_operations import build_commitment_record
+
+try:
+    from . import state_transaction_adapter
+    from . import system_log_validator
+except Exception:
+    import importlib.util
+    import sys
+
+    _base = Path(__file__).parent
+
+    _sta_path = _base / "state_transaction_adapter.py"
+    _spec = importlib.util.spec_from_file_location("system_state_transaction_adapter_slice24", str(_sta_path))
+    state_transaction_adapter = importlib.util.module_from_spec(_spec)
+    sys.modules[_spec.name] = state_transaction_adapter
+    _spec.loader.exec_module(state_transaction_adapter)
+
+    _slv_path = _base / "system_log_validator.py"
+    _spec = importlib.util.spec_from_file_location("system_log_validator_slice24", str(_slv_path))
+    system_log_validator = importlib.util.module_from_spec(_spec)
+    sys.modules[_spec.name] = system_log_validator
+    _spec.loader.exec_module(system_log_validator)
+
+
+def _canonical_sha256(value: Any) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _advance_transaction(
+    transaction: dict[str, Any],
+    target_state: str,
+    actor_id: str,
+    metadata_update: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    result = state_transaction_adapter.state_transaction_advance(
+        {
+            "transaction": transaction,
+            "target_state": target_state,
+            "actor_id": actor_id,
+            "metadata_update": metadata_update or {},
+        }
+    )
+    if "error" in result:
+        return None, result
+    return dict(result.get("transaction") or {}), None
+
+
+def _next_prev_hash(ledger_path: Path) -> str:
+    records = system_log_validator.load_ledger(ledger_path)
+    if not records:
+        return "genesis"
+    return system_log_validator.hash_record(records[-1])
+
+
+def _append_commitment(
+    *,
+    ledger_path: Path,
+    actor_id: str,
+    actor_role: str,
+    commitment_type: str,
+    subject_id: str,
+    summary: str,
+    metadata: dict[str, Any],
+    subject_hash: str | None = None,
+    domain_id: str | None = None,
+) -> dict[str, Any]:
+    record = build_commitment_record(
+        actor_id=actor_id,
+        actor_role=actor_role,
+        commitment_type=commitment_type,
+        subject_id=subject_id,
+        summary=summary,
+        subject_hash=subject_hash,
+        domain_id=domain_id,
+        metadata=metadata,
+        prev_record_hash=_next_prev_hash(ledger_path),
+    )
+    system_log_validator.append_record(ledger_path, record)
+    return record
+
+
+def commit_evidence_and_confirm_teardown(payload: dict[str, Any]) -> dict[str, Any]:
+    evidence_commit = payload.get("evidence_commit")
+    teardown_result = payload.get("teardown_result")
+    if not isinstance(evidence_commit, dict):
+        return {"status": "error", "error": "Missing or invalid 'evidence_commit' dict in payload"}
+    if not isinstance(teardown_result, dict):
+        return {"status": "error", "error": "Missing or invalid 'teardown_result' dict in payload"}
+
+    actor_id = str(payload.get("actor_id") or "system-pack")
+    actor_role = str(payload.get("actor_role") or "system")
+    domain_id = payload.get("domain_id")
+    ledger_raw = payload.get("ledger_path") or "data/system/system-log-ledger.jsonl"
+    ledger_path = Path(str(ledger_raw))
+
+    transaction_raw = payload.get("transaction")
+    if isinstance(transaction_raw, dict) and "transaction_id" in transaction_raw:
+        transaction = dict(transaction_raw)
+    else:
+        operation = str(payload.get("operation") or "system_evidence_commit_teardown")
+        transaction = StateTransaction(
+            operation=operation,
+            actor_id=actor_id,
+            metadata={
+                "plan_id": evidence_commit.get("plan_id"),
+                "slice_id": evidence_commit.get("slice_id"),
+                "node_id": evidence_commit.get("node_id"),
+                "lifecycle_state": "HarvestingEvidence",
+            },
+        ).to_dict()
+
+    current_state = str(transaction.get("state") or "")
+    if current_state == TransactionState.FINALIZED.value:
+        return {
+            "status": "already_finalized",
+            "transaction": transaction,
+            "ledger_path": str(ledger_path),
+            "records": [],
+            "lifecycle": [str((transaction.get("metadata") or {}).get("lifecycle_state") or "TeardownConfirmed")],
+        }
+
+    lifecycle: list[str] = []
+    records: list[dict[str, Any]] = []
+
+    if str(transaction.get("state") or "") == TransactionState.PROPOSED.value:
+        transaction, err = _advance_transaction(
+            transaction,
+            TransactionState.VALIDATED.value,
+            actor_id,
+            {"lifecycle_state": "HarvestingEvidence"},
+        )
+        if err is not None:
+            return {"status": "error", "error": err.get("error", "Failed to validate transaction"), "details": err}
+
+    if str(transaction.get("state") or "") != TransactionState.VALIDATED.value:
+        return {
+            "status": "error",
+            "error": "Transaction must be PROPOSED or VALIDATED for evidence commit",
+            "current_state": str(transaction.get("state") or ""),
+        }
+
+    evidence_hash = _canonical_sha256(evidence_commit)
+    transaction, err = _advance_transaction(
+        transaction,
+        TransactionState.COMMITTED.value,
+        actor_id,
+        {"lifecycle_state": "EvidenceCommitted", "evidence_hash": evidence_hash},
+    )
+    if err is not None:
+        return {"status": "error", "error": err.get("error", "Failed to commit transaction"), "details": err}
+    lifecycle.append("EvidenceCommitted")
+
+    subject_id = str(evidence_commit.get("node_id") or evidence_commit.get("slice_id") or evidence_commit.get("plan_id") or "unknown")
+    evidence_record = _append_commitment(
+        ledger_path=ledger_path,
+        actor_id=actor_id,
+        actor_role=actor_role,
+        commitment_type="evidence_commit",
+        subject_id=subject_id,
+        summary=f"Committed evidence for {subject_id}",
+        metadata={
+            "plan_id": evidence_commit.get("plan_id"),
+            "slice_id": evidence_commit.get("slice_id"),
+            "node_id": evidence_commit.get("node_id"),
+            "artifacts": list(evidence_commit.get("artifacts") or []),
+            "checksums": dict(evidence_commit.get("checksums") or {}),
+            "test_summary": dict(evidence_commit.get("test_summary") or {}),
+            "collected_at": evidence_commit.get("collected_at"),
+        },
+        subject_hash=evidence_hash,
+        domain_id=str(domain_id) if domain_id is not None else None,
+    )
+    records.append(evidence_record)
+
+    lifecycle.append("TearingDown")
+    failed_paths = list(teardown_result.get("failed") or [])
+    if failed_paths:
+        lifecycle.append("TeardownFailed")
+        escalation_record = _append_commitment(
+            ledger_path=ledger_path,
+            actor_id=actor_id,
+            actor_role=actor_role,
+            commitment_type="cleanup_escalated",
+            subject_id=subject_id,
+            summary=f"Teardown escalation for {subject_id}",
+            metadata={
+                "plan_id": teardown_result.get("plan_id"),
+                "slice_id": teardown_result.get("slice_id"),
+                "removed": list(teardown_result.get("removed") or []),
+                "failed": failed_paths,
+                "started_at": teardown_result.get("started_at"),
+                "completed_at": teardown_result.get("completed_at"),
+            },
+            domain_id=str(domain_id) if domain_id is not None else None,
+        )
+        records.append(escalation_record)
+
+        transaction, err = _advance_transaction(
+            transaction,
+            TransactionState.FINALIZED.value,
+            actor_id,
+            {"lifecycle_state": "CleanupEscalated", "teardown_status": "failed"},
+        )
+        if err is not None:
+            return {"status": "error", "error": err.get("error", "Failed to finalize transaction"), "details": err}
+
+        lifecycle.append("CleanupEscalated")
+        return {
+            "status": "escalated",
+            "transaction": transaction,
+            "ledger_path": str(ledger_path),
+            "records": records,
+            "lifecycle": lifecycle,
+        }
+
+    confirmation_record = _append_commitment(
+        ledger_path=ledger_path,
+        actor_id=actor_id,
+        actor_role=actor_role,
+        commitment_type="teardown_confirmation",
+        subject_id=subject_id,
+        summary=f"Teardown confirmed for {subject_id}",
+        metadata={
+            "plan_id": teardown_result.get("plan_id"),
+            "slice_id": teardown_result.get("slice_id"),
+            "removed": list(teardown_result.get("removed") or []),
+            "failed": [],
+            "started_at": teardown_result.get("started_at"),
+            "completed_at": teardown_result.get("completed_at"),
+        },
+        domain_id=str(domain_id) if domain_id is not None else None,
+    )
+    records.append(confirmation_record)
+
+    transaction, err = _advance_transaction(
+        transaction,
+        TransactionState.FINALIZED.value,
+        actor_id,
+        {"lifecycle_state": "TeardownConfirmed", "teardown_status": "confirmed"},
+    )
+    if err is not None:
+        return {"status": "error", "error": err.get("error", "Failed to finalize transaction"), "details": err}
+
+    lifecycle.append("TeardownConfirmed")
+    return {
+        "status": "ok",
+        "transaction": transaction,
+        "ledger_path": str(ledger_path),
+        "records": records,
+        "lifecycle": lifecycle,
+    }

--- a/model-packs/system/controllers/evidence_commit_teardown.py
+++ b/model-packs/system/controllers/evidence_commit_teardown.py
@@ -11,7 +11,7 @@ from lumina.system_log.admin_operations import build_commitment_record
 try:
     from . import state_transaction_adapter
     from . import system_log_validator
-except Exception:
+except ImportError:
     import importlib.util
     import sys
 
@@ -19,12 +19,16 @@ except Exception:
 
     _sta_path = _base / "state_transaction_adapter.py"
     _spec = importlib.util.spec_from_file_location("system_state_transaction_adapter_slice24", str(_sta_path))
+    if _spec is None or _spec.loader is None:
+        raise ImportError(f"Unable to load state_transaction_adapter from {_sta_path}")
     state_transaction_adapter = importlib.util.module_from_spec(_spec)
     sys.modules[_spec.name] = state_transaction_adapter
     _spec.loader.exec_module(state_transaction_adapter)
 
     _slv_path = _base / "system_log_validator.py"
     _spec = importlib.util.spec_from_file_location("system_log_validator_slice24", str(_slv_path))
+    if _spec is None or _spec.loader is None:
+        raise ImportError(f"Unable to load system_log_validator from {_slv_path}")
     system_log_validator = importlib.util.module_from_spec(_spec)
     sys.modules[_spec.name] = system_log_validator
     _spec.loader.exec_module(system_log_validator)
@@ -131,7 +135,8 @@ def commit_evidence_and_confirm_teardown(payload: dict[str, Any]) -> dict[str, A
     lifecycle: list[str] = []
     records: list[dict[str, Any]] = []
 
-    if str(transaction.get("state") or "") == TransactionState.PROPOSED.value:
+    state = str(transaction.get("state") or "")
+    if state == TransactionState.PROPOSED.value:
         transaction, err = _advance_transaction(
             transaction,
             TransactionState.VALIDATED.value,
@@ -141,45 +146,50 @@ def commit_evidence_and_confirm_teardown(payload: dict[str, Any]) -> dict[str, A
         if err is not None:
             return {"status": "error", "error": err.get("error", "Failed to validate transaction"), "details": err}
 
-    if str(transaction.get("state") or "") != TransactionState.VALIDATED.value:
+        state = str(transaction.get("state") or "")
+
+    if state not in (TransactionState.VALIDATED.value, TransactionState.COMMITTED.value):
         return {
             "status": "error",
-            "error": "Transaction must be PROPOSED or VALIDATED for evidence commit",
-            "current_state": str(transaction.get("state") or ""),
+            "error": "Transaction must be PROPOSED, VALIDATED, or COMMITTED for evidence commit",
+            "current_state": state,
         }
 
     evidence_hash = _canonical_sha256(evidence_commit)
-    transaction, err = _advance_transaction(
-        transaction,
-        TransactionState.COMMITTED.value,
-        actor_id,
-        {"lifecycle_state": "EvidenceCommitted", "evidence_hash": evidence_hash},
-    )
-    if err is not None:
-        return {"status": "error", "error": err.get("error", "Failed to commit transaction"), "details": err}
-    lifecycle.append("EvidenceCommitted")
+    if state == TransactionState.VALIDATED.value:
+        transaction, err = _advance_transaction(
+            transaction,
+            TransactionState.COMMITTED.value,
+            actor_id,
+            {"lifecycle_state": "EvidenceCommitted", "evidence_hash": evidence_hash},
+        )
+        if err is not None:
+            return {"status": "error", "error": err.get("error", "Failed to commit transaction"), "details": err}
+
+        subject_id = str(evidence_commit.get("node_id") or evidence_commit.get("slice_id") or evidence_commit.get("plan_id") or "unknown")
+        evidence_record = _append_commitment(
+            ledger_path=ledger_path,
+            actor_id=actor_id,
+            actor_role=actor_role,
+            commitment_type="evidence_commit",
+            subject_id=subject_id,
+            summary=f"Committed evidence for {subject_id}",
+            metadata={
+                "plan_id": evidence_commit.get("plan_id"),
+                "slice_id": evidence_commit.get("slice_id"),
+                "node_id": evidence_commit.get("node_id"),
+                "artifacts": list(evidence_commit.get("artifacts") or []),
+                "checksums": dict(evidence_commit.get("checksums") or {}),
+                "test_summary": dict(evidence_commit.get("test_summary") or {}),
+                "collected_at": evidence_commit.get("collected_at"),
+            },
+            subject_hash=evidence_hash,
+            domain_id=str(domain_id) if domain_id is not None else None,
+        )
+        records.append(evidence_record)
 
     subject_id = str(evidence_commit.get("node_id") or evidence_commit.get("slice_id") or evidence_commit.get("plan_id") or "unknown")
-    evidence_record = _append_commitment(
-        ledger_path=ledger_path,
-        actor_id=actor_id,
-        actor_role=actor_role,
-        commitment_type="evidence_commit",
-        subject_id=subject_id,
-        summary=f"Committed evidence for {subject_id}",
-        metadata={
-            "plan_id": evidence_commit.get("plan_id"),
-            "slice_id": evidence_commit.get("slice_id"),
-            "node_id": evidence_commit.get("node_id"),
-            "artifacts": list(evidence_commit.get("artifacts") or []),
-            "checksums": dict(evidence_commit.get("checksums") or {}),
-            "test_summary": dict(evidence_commit.get("test_summary") or {}),
-            "collected_at": evidence_commit.get("collected_at"),
-        },
-        subject_hash=evidence_hash,
-        domain_id=str(domain_id) if domain_id is not None else None,
-    )
-    records.append(evidence_record)
+    lifecycle.append("EvidenceCommitted")
 
     lifecycle.append("TearingDown")
     failed_paths = list(teardown_result.get("failed") or [])

--- a/tests/test_system_evidence_commit_and_teardown.py
+++ b/tests/test_system_evidence_commit_and_teardown.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+
+
+def _load_module(name: str, path: pathlib.Path):
+    spec = importlib.util.spec_from_file_location(name, str(path))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+BASE = pathlib.Path(__file__).resolve().parents[1]
+CONTROLLERS = BASE / "model-packs" / "system" / "controllers"
+
+evidence_commit_teardown = _load_module(
+    "system_evidence_commit_teardown_slice24",
+    CONTROLLERS / "evidence_commit_teardown.py",
+)
+system_log_validator = _load_module(
+    "system_log_validator_slice24",
+    CONTROLLERS / "system_log_validator.py",
+)
+
+
+def _payload(*, failed: list[dict[str, str]] | None = None) -> dict:
+    return {
+        "actor_id": "system-pack",
+        "actor_role": "system",
+        "evidence_commit": {
+            "plan_id": "plan-24",
+            "slice_id": "slice-24",
+            "node_id": "node-24",
+            "artifacts": [{"path": "tmp/out.txt", "sha256": "abc"}],
+            "test_summary": {"passed": True, "summary": "ok"},
+            "checksums": {"tmp/out.txt": "abc"},
+            "collected_at": "2026-07-07T00:00:00Z",
+        },
+        "teardown_result": {
+            "plan_id": "plan-24",
+            "slice_id": "slice-24",
+            "removed": ["tmp/build"],
+            "failed": list(failed or []),
+            "started_at": "2026-07-07T00:01:00Z",
+            "completed_at": "2026-07-07T00:02:00Z",
+        },
+    }
+
+
+def test_commit_and_confirm_teardown_success(tmp_path):
+    ledger = tmp_path / "system-log-ledger.jsonl"
+    payload = _payload()
+    payload["ledger_path"] = str(ledger)
+
+    result = evidence_commit_teardown.commit_evidence_and_confirm_teardown(payload)
+
+    assert result["status"] == "ok"
+    assert result["transaction"]["state"] == "FINALIZED"
+    assert result["lifecycle"] == ["EvidenceCommitted", "TearingDown", "TeardownConfirmed"]
+
+    records = system_log_validator.load_ledger(ledger)
+    assert len(records) == 2
+    assert records[0]["commitment_type"] == "evidence_commit"
+    assert records[1]["commitment_type"] == "teardown_confirmation"
+
+
+def test_commit_and_confirm_teardown_escalates_on_failure(tmp_path):
+    ledger = tmp_path / "system-log-ledger.jsonl"
+    payload = _payload(failed=[{"path": "tmp/build", "error": "permission denied"}])
+    payload["ledger_path"] = str(ledger)
+
+    result = evidence_commit_teardown.commit_evidence_and_confirm_teardown(payload)
+
+    assert result["status"] == "escalated"
+    assert result["transaction"]["state"] == "FINALIZED"
+    assert result["lifecycle"][-2:] == ["TeardownFailed", "CleanupEscalated"]
+
+    records = system_log_validator.load_ledger(ledger)
+    assert len(records) == 2
+    assert records[0]["commitment_type"] == "evidence_commit"
+    assert records[1]["commitment_type"] == "cleanup_escalated"
+
+
+def test_commit_and_confirm_teardown_is_idempotent_for_finalized(tmp_path):
+    ledger = tmp_path / "system-log-ledger.jsonl"
+    payload = _payload()
+    payload["ledger_path"] = str(ledger)
+
+    first = evidence_commit_teardown.commit_evidence_and_confirm_teardown(payload)
+    second = evidence_commit_teardown.commit_evidence_and_confirm_teardown(
+        {
+            **payload,
+            "transaction": first["transaction"],
+        }
+    )
+
+    assert first["status"] == "ok"
+    assert second["status"] == "already_finalized"
+
+    records = system_log_validator.load_ledger(ledger)
+    assert len(records) == 2
+
+
+def test_commit_and_confirm_teardown_rejects_invalid_payload():
+    result = evidence_commit_teardown.commit_evidence_and_confirm_teardown({})
+    assert result["status"] == "error"
+    assert "evidence_commit" in result["error"]

--- a/tests/test_system_evidence_commit_and_teardown.py
+++ b/tests/test_system_evidence_commit_and_teardown.py
@@ -7,10 +7,11 @@ import sys
 
 def _load_module(name: str, path: pathlib.Path):
     spec = importlib.util.spec_from_file_location(name, str(path))
+    assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules[name] = module
     spec.loader.exec_module(module)
-    return module
+    return sys.modules[name]
 
 
 BASE = pathlib.Path(__file__).resolve().parents[1]
@@ -102,6 +103,31 @@ def test_commit_and_confirm_teardown_is_idempotent_for_finalized(tmp_path):
 
     records = system_log_validator.load_ledger(ledger)
     assert len(records) == 2
+
+
+def test_commit_and_confirm_teardown_resumes_from_committed_without_duplicate_evidence(tmp_path):
+    ledger = tmp_path / "system-log-ledger.jsonl"
+    payload = _payload()
+    payload["ledger_path"] = str(ledger)
+
+    base = evidence_commit_teardown.commit_evidence_and_confirm_teardown(payload)
+    committed_tx = dict(base["transaction"])
+    committed_tx["state"] = "COMMITTED"
+
+    result = evidence_commit_teardown.commit_evidence_and_confirm_teardown(
+        {
+            **payload,
+            "transaction": committed_tx,
+        }
+    )
+
+    assert result["status"] == "ok"
+    assert result["transaction"]["state"] == "FINALIZED"
+    assert result["lifecycle"] == ["EvidenceCommitted", "TearingDown", "TeardownConfirmed"]
+
+    records = system_log_validator.load_ledger(ledger)
+    assert len(records) == 3
+    assert records[-1]["commitment_type"] == "teardown_confirmation"
 
 
 def test_commit_and_confirm_teardown_rejects_invalid_payload():


### PR DESCRIPTION
## Summary
- Implement Slice 24: system-led evidence commit and teardown confirmation flow.
- Add system controller for commit/teardown lifecycle handling and escalation pathing.
- Wire runtime adapter registration for commit flow in system runtime config.
- Add Slice 24 roadmap doc and repair manifest coverage for slices 22-24.

## Code Changes
- Added system handler: commit evidence, advance transaction states, append commitment records, and return lifecycle markers.
- Added tests for success, escalation, idempotency, and invalid payload handling.
- Updated runtime tool adapter wiring to expose `commit_evidence_and_confirm_teardown`.
- Updated `docs/MANIFEST.yaml` to include missing roadmap slice docs and regenerated hashes.

## Verification
- Focused manifest checks:
  - `tests/test_schema_versioning.py::TestManifestCoverage::test_all_docs_tracked`
  - `tests/test_system_log_integrity.py::TestManifestIntegrity::test_manifest_check_passes`
  - Result: pass
- Full suite:
  - `python -m pytest -q`
  - Result: `5202 passed, 2 skipped, 68 warnings` (72.51s)

## Notes
- Two skips are environment-gated tests.
- Warnings are existing deprecation notices (primarily `datetime.utcnow()` usage in coding-agent modules).