### PR TITLE
Add B2B institutional-memory ERPNext roadmap slices

### DIFF
--- a/docs/MANIFEST.yaml
+++ b/docs/MANIFEST.yaml
@@ -106,6 +106,62 @@ artifacts:
   status: delivered
   last_updated: 2026-07-07
   sha256: 9af25640eb15e2ed52e3210ed12bc79e9f88a6efa630d96c7765d59a3095b4e8
+- path: docs/roadmap/slices/25-b2b-workstream-boundary-and-task-graph.md
+  type: doc
+  section: 0
+  doc_version: 1.0.0
+  status: planned
+  last_updated: 2026-07-11
+  sha256: 3f789fd940de17239fca4471073fe4100e293217de745cd4debef59dc3a23908
+- path: docs/roadmap/slices/26-tenant-site-actor-memory-contracts.md
+  type: doc
+  section: 0
+  doc_version: 1.0.0
+  status: planned
+  last_updated: 2026-07-11
+  sha256: 6e3e10dadccae8b0e35ec99d3769dafaa89c92c3420100798d3910cb8068c1ac
+- path: docs/roadmap/slices/27-institutional-vector-memory-layer.md
+  type: doc
+  section: 0
+  doc_version: 1.0.0
+  status: planned
+  last_updated: 2026-07-11
+  sha256: d7448762c2f1b6fd036c0c6ae2b038b506efdf734bc56530b818756b76648612
+- path: docs/roadmap/slices/28-semantic-thread-routing-and-forking.md
+  type: doc
+  section: 0
+  doc_version: 1.0.0
+  status: planned
+  last_updated: 2026-07-11
+  sha256: 5bb3dca25408d17a6dd704a8a4e618da9dd3c49280d7233b21b41f72aabc9f2a
+- path: docs/roadmap/slices/29-decision-precedent-confidence-and-escalation.md
+  type: doc
+  section: 0
+  doc_version: 1.0.0
+  status: planned
+  last_updated: 2026-07-11
+  sha256: 6a304e2d0d4a0705c62552cd29535969fbb613f582b726a839e25fc27764e5df
+- path: docs/roadmap/slices/30-erpnext-adapter-foundation-and-fixtures.md
+  type: doc
+  section: 0
+  doc_version: 1.0.0
+  status: planned
+  last_updated: 2026-07-11
+  sha256: 6c56436d9d0a2cdbcab08bd919ba7ce44b325779228215c0dd236f6fbe867ef6
+- path: docs/roadmap/slices/31-business-ops-pack-bootstrap.md
+  type: doc
+  section: 0
+  doc_version: 1.0.0
+  status: planned
+  last_updated: 2026-07-11
+  sha256: 37c0d82d5fcf1baf1fc9a5cde72d9ed2db3120a5fa0381dc665c115c6b8a91f0
+- path: docs/roadmap/slices/32-auto-repair-mvp-and-single-box-deployment.md
+  type: doc
+  section: 0
+  doc_version: 1.0.0
+  status: planned
+  last_updated: 2026-07-11
+  sha256: 79b8765877e708b41cf8fdab003e821e6551961ff403a13ac9dd656402336f27
 - path: docs/1-commands/README.md
   type: doc
   section: 1
@@ -1873,7 +1929,7 @@ artifacts:
   doc_version: 1.0.0
   status: active
   last_updated: 2026-06-18
-  sha256: 0f07628f486f76c47028449c3a1a107dfe268fcc89dd5af8758c5772073807ba
+  sha256: bc6610499e4a2533a8bf51a55435485af6aa414d60dde438a0961163801c14ff
 - path: docs/roadmap/slices/01-framework-boundary.md
   type: doc
   doc_version: 1.0.0

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -50,6 +50,14 @@ under `docs/roadmap/slices/` and delivered as a focused PR.
 | [22](slices/22-system-pack-activation-gate.md) | System Pack Approval / Activation Gate | Delivered |
 | [23](slices/23-evidence-harvest-and-teardown.md) | Evidence Harvest and Teardown | Delivered |
 | [24](slices/24-system-led-evidence-commit-and-teardown-confirmation.md) | System-Led Evidence Commit and Teardown Confirmation | Delivered |
+| [25](slices/25-b2b-workstream-boundary-and-task-graph.md) | B2B Workstream Boundary and Global Task Graph | Planned |
+| [26](slices/26-tenant-site-actor-memory-contracts.md) | Tenant/Site/Actor Memory Contracts | Planned |
+| [27](slices/27-institutional-vector-memory-layer.md) | Institutional Vector Memory Layer | Planned |
+| [28](slices/28-semantic-thread-routing-and-forking.md) | Semantic Thread Routing and Context Forking | Planned |
+| [29](slices/29-decision-precedent-confidence-and-escalation.md) | Decision Precedent, Confidence, and Escalation | Planned |
+| [30](slices/30-erpnext-adapter-foundation-and-fixtures.md) | ERPNext Adapter Foundation and Deterministic Fixtures | Planned |
+| [31](slices/31-business-ops-pack-bootstrap.md) | Business Ops Pack Bootstrap | Planned |
+| [32](slices/32-auto-repair-mvp-and-single-box-deployment.md) | Auto Repair MVP and Single-Box Deployment Topology | Planned |
 
 ---
 

--- a/docs/roadmap/slices/25-b2b-workstream-boundary-and-task-graph.md
+++ b/docs/roadmap/slices/25-b2b-workstream-boundary-and-task-graph.md
@@ -1,0 +1,70 @@
+---
+title: "Slice 25 — B2B Workstream Boundary and Global Task Graph"
+slice: 25
+status: planned
+version: 0.1.0
+last_updated: 2026-07-11
+---
+
+## Purpose
+
+Define the implementation boundary for the `b2b-institutional-memory-erpnext-architecture` workstream so ERPNext remains the operational source of record and Lumina remains the semantic memory, decision precedent, escalation, and bounded automation layer.
+
+## Scope
+
+- Formalize the global task graph and phase order for the B2B workstream.
+- Record explicit system boundaries: ERP state ownership, Lumina memory ownership, and governance constraints.
+- Define non-negotiable constraints for credentials, transcript handling, and deterministic test posture.
+
+## Out of Scope
+
+- New runtime code, APIs, adapters, migrations, or UI changes.
+- Live ERPNext connectivity.
+- New model-pack extraction from the repository.
+
+## Required Changes
+
+- New slice specification documenting the full workstream graph and implementation sequence.
+- Add this slice to the roadmap index with `Planned` status.
+
+## New/Changed Contracts
+
+- New roadmap contract: `b2b-institutional-memory-erpnext-architecture` global task graph.
+- Architectural boundary contract:
+  - ERPNext owns transactional system-of-record objects.
+  - Lumina owns semantic retrieval, precedent evaluation, confidence scoring, and escalation packets.
+- Security contract:
+  - No credentials in prompts, telemetry payloads, checkpoints, or generated artifacts.
+  - No raw transcript persistence as required institutional-memory substrate.
+
+## Files Likely Touched
+
+- `docs/roadmap/README.md`
+- `docs/roadmap/slices/25-b2b-workstream-boundary-and-task-graph.md`
+
+## Acceptance Criteria
+
+- Workstream scope explicitly separates source-of-record duties from semantic/reasoning duties.
+- Slice sequence is explicit and dependency-ordered.
+- Constraints match framework posture:
+  - local-first deployment,
+  - API-first ERP integration,
+  - deterministic tests before live integration,
+  - bounded authority gates preserved.
+
+## Tests
+
+- Documentation consistency check:
+  - roadmap index includes Slice 25.
+  - section headings match roadmap convention.
+
+## Ledger/Governance Impact
+
+- No runtime ledger behavior change.
+- Planning-only governance clarification to prevent accidental authority expansion into the business domain.
+
+## Follow-Up Slices
+
+- Slice 26: tenant/site/actor-scoped memory contracts.
+- Slice 27: institutional vector memory layer.
+- Slice 28: semantic thread routing and forking.

--- a/docs/roadmap/slices/26-tenant-site-actor-memory-contracts.md
+++ b/docs/roadmap/slices/26-tenant-site-actor-memory-contracts.md
@@ -1,0 +1,72 @@
+---
+title: "Slice 26 — Tenant/Site/Actor Memory Contracts"
+slice: 26
+status: planned
+version: 0.1.0
+last_updated: 2026-07-11
+---
+
+## Purpose
+
+Introduce explicit identity and scoping contracts for institutional memory so retrieval and precedent logic are safely partitioned by organization, site, actor, and operational context.
+
+## Scope
+
+- Define new schema contracts for organizational scope:
+  - `organization_id`,
+  - `site_id`,
+  - `actor_id`,
+  - `device_id` (optional),
+  - ERP document references.
+- Define memory record contract families:
+  - institutional memory record,
+  - decision precedent record,
+  - thread summary record,
+  - ERP event mirror record.
+- Specify how these contracts align with existing profile/session/log persistence abstractions.
+
+## Out of Scope
+
+- Database migration implementation.
+- Runtime retrieval changes.
+- ERP adapter implementation.
+
+## Required Changes
+
+- Add standards-level schema drafts for scoped memory records.
+- Add concept documentation describing identity propagation through session, profile, retrieval, and escalation surfaces.
+
+## New/Changed Contracts
+
+- New memory scoping contract: all institutional memory artifacts must be filterable by organization and site.
+- New actor linkage contract: memory artifacts should optionally link to actor and device sources.
+- New ERP reference contract: memory records may carry stable ERP doctype/document keys without embedding credentials.
+
+## Files Likely Touched
+
+- `standards/retrieval-index-schema-v1.json`
+- `standards/*.json` (new memory record schemas)
+- `docs/7-concepts/*.md` (new institutional-memory concept note)
+- `docs/roadmap/slices/26-tenant-site-actor-memory-contracts.md`
+
+## Acceptance Criteria
+
+- Contracts support strict organization/site scoping for retrieval.
+- Contracts are compatible with local-first storage and deterministic replay tests.
+- Contracts prohibit credential-bearing fields.
+- Contracts do not require raw transcript persistence for institutional memory continuity.
+
+## Tests
+
+- Schema validation tests for all new contracts.
+- Deterministic fixture tests proving scope filters prevent cross-tenant retrieval.
+
+## Ledger/Governance Impact
+
+- Enables ledger-linked institutional evidence envelopes with explicit actor/site provenance.
+- No change to existing authority gates; this slice only defines data contracts.
+
+## Follow-Up Slices
+
+- Slice 27: institutional vector memory indexing and retrieval policy.
+- Slice 29: confidence and escalation rules consume these contracts.

--- a/docs/roadmap/slices/27-institutional-vector-memory-layer.md
+++ b/docs/roadmap/slices/27-institutional-vector-memory-layer.md
@@ -1,0 +1,72 @@
+---
+title: "Slice 27 — Institutional Vector Memory Layer"
+slice: 27
+status: planned
+version: 0.1.0
+last_updated: 2026-07-11
+---
+
+## Purpose
+
+Extend the existing retrieval stack into a tenant/site/actor-scoped institutional memory layer that stores and retrieves operational precedent, summaries, and ERP-linked evidence while preserving local-first deployment.
+
+## Scope
+
+- Define indexing and retrieval behavior for institutional memory artifacts.
+- Specify incremental ingestion from decision records, summaries, and ERP event mirrors.
+- Specify filter and ranking rules combining semantic similarity with strict scope constraints.
+- Define rollout path from current flat-file vector stores to pluggable local backends without API contract breakage.
+
+## Out of Scope
+
+- Replacing the current vector backend in this slice.
+- Advanced ANN/cluster infrastructure.
+- Cloud-hosted vector dependencies.
+
+## Required Changes
+
+- Add retrieval subsystem design docs for scoped institutional indexing.
+- Add interface updates for scoped store registry and filter-aware search.
+- Add deterministic benchmark fixtures for memory recall quality.
+
+## New/Changed Contracts
+
+- New scoped retrieval contract:
+  - hard filters (`organization_id`, `site_id`) before scoring,
+  - optional filters (`actor_id`, `module_key`, ERP doctype/id).
+- New memory ingestion contract:
+  - index summaries and decision/evidence artifacts,
+  - raw transcripts optional and not required.
+- New store abstraction contract for backend portability (flat-file now, local DB/vector engine later).
+
+## Files Likely Touched
+
+- `src/lumina/retrieval/vector_store.py`
+- `src/lumina/retrieval/housekeeper.py`
+- `src/lumina/orchestrator/knowledge_retriever.py`
+- `src/lumina/core/nlp.py`
+- `tests/test_retrieval.py`
+- `docs/roadmap/slices/27-institutional-vector-memory-layer.md`
+
+## Acceptance Criteria
+
+- Retrieval can enforce organization/site scope deterministically.
+- Institutional-memory search works without requiring transcript replay.
+- Existing domain retrieval remains backward compatible.
+- All tests run with fake/local fixtures only.
+
+## Tests
+
+- Deterministic retrieval unit tests with synthetic institutional records.
+- Scope-isolation tests proving no cross-site leakage.
+- Regression tests for current `KnowledgeIndex` and domain retrieval flows.
+
+## Ledger/Governance Impact
+
+- Improves evidence traceability by tying recalled memory items to scoped artifact identities.
+- No direct authority changes; retrieval remains advisory until policy gates permit action.
+
+## Follow-Up Slices
+
+- Slice 28: semantic thread routing and fork/merge behavior.
+- Slice 29: confidence scoring and escalation policy on retrieved precedent.

--- a/docs/roadmap/slices/28-semantic-thread-routing-and-forking.md
+++ b/docs/roadmap/slices/28-semantic-thread-routing-and-forking.md
@@ -1,0 +1,70 @@
+---
+title: "Slice 28 — Semantic Thread Routing and Context Forking"
+slice: 28
+status: planned
+version: 0.1.0
+last_updated: 2026-07-11
+---
+
+## Purpose
+
+Replace timestamp-only session creation defaults with semantic routing that can attach new turns to relevant active threads, create new threads when unmatched, and fork context on topic drift.
+
+## Scope
+
+- Define thread-matching policy using scoped vector retrieval + confidence thresholds.
+- Define fork/merge rules and operator intercept prompts.
+- Define rolling recap contract for long-running thread compression into summary state.
+- Define compatibility behavior with existing transcript seals and session resume paths.
+
+## Out of Scope
+
+- Full UI redesign.
+- Auto-merge behavior without operator visibility.
+- Persistence backend replacement.
+
+## Required Changes
+
+- Add router policy documentation and data contract for thread candidates.
+- Add client/server interface spec for attach/new/fork decisions.
+- Add deterministic test matrix for routing outcomes.
+
+## New/Changed Contracts
+
+- New `thread_routing_decision` contract:
+  - `attach_existing`,
+  - `create_new`,
+  - `fork_from`.
+- New `thread_summary_state` contract for recap-based continuity.
+- New confidence threshold policy contract with explicit override behavior.
+
+## Files Likely Touched
+
+- `src/web/app.tsx`
+- `src/web/services/transcriptStore.ts`
+- `src/lumina/api/processing.py`
+- `src/lumina/api/pipeline/payload.py`
+- `tests/*thread*` (new)
+- `docs/roadmap/slices/28-semantic-thread-routing-and-forking.md`
+
+## Acceptance Criteria
+
+- New user turn can be routed to existing relevant thread when confidence is high and scope matches.
+- Topic drift can produce deterministic fork behavior with explicit rationale.
+- Operator can override routing decision.
+- Raw transcript retention remains optional and not required for thread continuity.
+
+## Tests
+
+- Deterministic routing tests with fixed embeddings/fixtures.
+- Regression tests for existing session create/resume behavior.
+- Fork/merge policy tests across same-site and cross-site boundaries.
+
+## Ledger/Governance Impact
+
+- Routing decisions become auditable evidence artifacts (including confidence and rationale).
+- No direct privilege changes.
+
+## Follow-Up Slices
+
+- Slice 29: precedent confidence and escalation consumes routed thread context.

--- a/docs/roadmap/slices/29-decision-precedent-confidence-and-escalation.md
+++ b/docs/roadmap/slices/29-decision-precedent-confidence-and-escalation.md
@@ -1,0 +1,74 @@
+---
+title: "Slice 29 — Decision Precedent, Confidence, and Escalation"
+slice: 29
+status: planned
+version: 0.1.0
+last_updated: 2026-07-11
+---
+
+## Purpose
+
+Codify institutional decision precedent retrieval and confidence scoring so Lumina can propose proxy decisions when safe and escalate high-liability or low-confidence cases to human authority.
+
+## Scope
+
+- Define confidence model inputs:
+  - precedent similarity,
+  - scope match,
+  - recency,
+  - risk class.
+- Define action policy tiers:
+  - suggest-only,
+  - require confirmation,
+  - mandatory escalation.
+- Define escalation packet shape for owner/manager approvals.
+
+## Out of Scope
+
+- Push-notification transport implementation.
+- Final mobile UX.
+- Automated execution of high-liability physical operations.
+
+## Required Changes
+
+- Add precedent evaluation policy spec and confidence rubric.
+- Add escalation contract spec aligned with existing system escalation records.
+- Add deterministic fixtures demonstrating safe/unsafe recommendation boundaries.
+
+## New/Changed Contracts
+
+- New `precedent_match` contract with provenance and confidence evidence.
+- New `decision_confidence_score` contract with transparent component fields.
+- New `business_escalation_packet` contract for targeted approval requests.
+
+## Files Likely Touched
+
+- `standards/escalation-record-schema-v1.json`
+- `standards/domain-evidence-schema-v1.json`
+- `src/lumina/orchestrator/actor_resolver.py`
+- `src/lumina/api/pipeline/response.py`
+- `tests/test_*escalation*` (new)
+- `docs/roadmap/slices/29-decision-precedent-confidence-and-escalation.md`
+
+## Acceptance Criteria
+
+- Confidence score is deterministic for fixed fixture inputs.
+- Policy tiers are enforceable without model-side hidden behavior.
+- High-risk decisions always escalate.
+- Decision rationale is audit-visible and replayable.
+
+## Tests
+
+- Deterministic score calculation tests.
+- Policy threshold tests (`suggest`, `confirm`, `escalate`).
+- Regression tests for existing standing-order escalation paths.
+
+## Ledger/Governance Impact
+
+- Adds formal precedent-evidence and confidence traces to governance packets.
+- Preserves System Pack authority boundaries; recommendations do not equal activation.
+
+## Follow-Up Slices
+
+- Slice 30: ERPNext adapter foundation.
+- Slice 31: business-ops pack bootstrap uses precedent/escalation policies.

--- a/docs/roadmap/slices/30-erpnext-adapter-foundation-and-fixtures.md
+++ b/docs/roadmap/slices/30-erpnext-adapter-foundation-and-fixtures.md
@@ -1,0 +1,66 @@
+---
+title: "Slice 30 — ERPNext Adapter Foundation and Deterministic Fixtures"
+slice: 30
+status: planned
+version: 0.1.0
+last_updated: 2026-07-11
+---
+
+## Purpose
+
+Define API-first ERPNext integration contracts and deterministic fake-fixture execution so business workflows can be developed and validated before live ERP connectivity.
+
+## Scope
+
+- Define ERP adapter abstraction surface for read/write operations.
+- Define allowlisted operation catalog for initial business workflows.
+- Define fixture-driven simulation mode for deterministic CI and local development.
+- Define credential-handling boundaries external to prompt payloads.
+
+## Out of Scope
+
+- Live ERPNext deployment provisioning.
+- Browser automation as primary integration path.
+- Production secret management implementation details.
+
+## Required Changes
+
+- Add ERP adapter interface and operation schemas.
+- Add fixture framework and deterministic replay cases.
+- Add docs for API-first policy and headless-browser fallback policy.
+
+## New/Changed Contracts
+
+- New `erpnext_adapter` contract with operation signatures and response envelopes.
+- New `erpnext_fixture_scenario` contract for test replay.
+- New security contract: credentials are provided only via runtime environment/secrets layer, never model prompts.
+
+## Files Likely Touched
+
+- `model-packs/template/modules/*/tool-adapters/*.yaml`
+- `model-packs/*/controllers/tool_adapters.py` (new ERP adapter family)
+- `tests/test_*erpnext*` (new)
+- `docs/roadmap/slices/30-erpnext-adapter-foundation-and-fixtures.md`
+
+## Acceptance Criteria
+
+- All ERP operations used by downstream slices run against fake fixtures deterministically.
+- Adapter requests/responses are schema-validated.
+- No credentials appear in prompt contracts, telemetry payloads, or test artifacts.
+- Headless/browser automation remains explicitly secondary fallback.
+
+## Tests
+
+- Fixture replay tests for read and draft-write operations.
+- Contract tests for adapter request/response schemas.
+- Negative tests for unauthorized operations and malformed payloads.
+
+## Ledger/Governance Impact
+
+- ERP mutation intents become evidence-bearing operations with deterministic audit shape.
+- Final authority to commit high-impact changes remains under governance gates.
+
+## Follow-Up Slices
+
+- Slice 31: business ops pack consumes ERP adapter contracts.
+- Slice 32: auto-repair MVP executes end-to-end fixture scenarios.

--- a/docs/roadmap/slices/31-business-ops-pack-bootstrap.md
+++ b/docs/roadmap/slices/31-business-ops-pack-bootstrap.md
@@ -1,0 +1,65 @@
+---
+title: "Slice 31 — Business Ops Pack Bootstrap"
+slice: 31
+status: planned
+version: 0.1.0
+last_updated: 2026-07-11
+---
+
+## Purpose
+
+Bootstrap a reusable business-operations model pack (from template patterns) that binds actor model, scoped institutional memory, ERP adapter calls, and bounded governance behavior.
+
+## Scope
+
+- Define business-ops pack skeleton (manifest, runtime config, domain physics, profiles, role map).
+- Define actor types and groups suitable for SMB operations contexts.
+- Define initial operation categories and bounded standing orders.
+- Define module extension posture for verticals (auto repair first, others later).
+
+## Out of Scope
+
+- Full multi-vertical implementation.
+- Production UI polish.
+- Billing/commercial packaging logic.
+
+## Required Changes
+
+- Create business-ops pack slice spec aligned with template pack anatomy.
+- Define module-map strategy and role/permission model.
+- Define domain profile extension fields required by institutional memory and ERP references.
+
+## New/Changed Contracts
+
+- New `business-ops` domain-pack contract (pack identity + module boundaries).
+- New role and actor contracts for owner/manager/operator/front-desk/customer-intake contexts.
+- New profile extension contract including organization/site defaults and memory policy flags.
+
+## Files Likely Touched
+
+- `model-packs/template/pack.yaml`
+- `model-packs/template/cfg/runtime-config.yaml`
+- `model-packs/template/cfg/domain-profile-extension.yaml`
+- `docs/7-concepts/domain-pack-anatomy.md`
+- `docs/roadmap/slices/31-business-ops-pack-bootstrap.md`
+
+## Acceptance Criteria
+
+- Pack scaffold follows HMVC and runtime adapter contract patterns already used in framework.
+- Actor, role, and profile contracts align with scoped memory and ERP adapter requirements.
+- Governance boundaries stay consistent with System Pack authority model.
+
+## Tests
+
+- Structural pack tests (manifest/runtime-config/domain-physics shape).
+- Role/permission contract tests.
+- Profile merge tests for base/domain/role composition.
+
+## Ledger/Governance Impact
+
+- Introduces business-domain governance semantics without changing system authority ownership.
+- Ensures all bounded operations remain traceable through existing audit model.
+
+## Follow-Up Slices
+
+- Slice 32: first vertical module (auto repair) and deployment/test readiness.

--- a/docs/roadmap/slices/32-auto-repair-mvp-and-single-box-deployment.md
+++ b/docs/roadmap/slices/32-auto-repair-mvp-and-single-box-deployment.md
@@ -1,0 +1,76 @@
+---
+title: "Slice 32 — Auto Repair MVP and Single-Box Deployment Topology"
+slice: 32
+status: planned
+version: 0.1.0
+last_updated: 2026-07-11
+---
+
+## Purpose
+
+Define the first vertical implementation (independent auto repair) and the local-first single-box deployment model that combines ERPNext + Lumina institutional memory + bounded agentic tooling.
+
+## Scope
+
+- Define auto-repair MVP module workflows:
+  - intake to structured repair order draft,
+  - precedent-assisted technician support,
+  - bounded escalation to owner/manager approval,
+  - ERP draft updates through adapters.
+- Define single-box deployment topology and multi-site thin-client extension pattern.
+- Define deterministic end-to-end scenario fixtures spanning memory, precedent, and ERP adapter layers.
+
+## Out of Scope
+
+- General availability hardening for all verticals.
+- Full POS and restaurant implementation.
+- Production remote notification transport implementation.
+
+## Required Changes
+
+- Add auto-repair module slice spec with actor flows and operation boundaries.
+- Add deployment architecture note for local server + VPN-based multi-site access.
+- Add deterministic E2E fixture plan with fake ERPNext responses.
+
+## New/Changed Contracts
+
+- New auto-repair module contract for task/event shapes.
+- New deployment contract for local-first runtime assumptions:
+  - ERP and Lumina colocated,
+  - secure LAN/VLAN boundary,
+  - optional VPN for remote/site-2 access.
+- New E2E fixture contract linking thread routing, precedent scoring, and ERP operation replay.
+
+## Files Likely Touched
+
+- `model-packs/*/modules/*/domain-physics.json` (new auto-repair module)
+- `docs/7-concepts/*.md` (new deployment architecture concept)
+- `tests/test_*business_ops*` (new)
+- `tests/test_*erpnext*` (expanded)
+- `docs/roadmap/slices/32-auto-repair-mvp-and-single-box-deployment.md`
+
+## Acceptance Criteria
+
+- End-to-end deterministic scenario runs with fake ERP fixtures:
+  - complaint -> structured draft repair order,
+  - precedent retrieval -> confidence-scored recommendation,
+  - high-risk case -> escalation packet,
+  - approval -> bounded ERP draft mutation.
+- Deployment topology documented for one-site and thin-client multi-site cases.
+- No prompts require credentials; no raw transcript persistence required for institutional continuity.
+
+## Tests
+
+- Deterministic integration tests with fixture replay only.
+- Contract tests for escalation packets and decision traces.
+- Retrieval isolation tests across organization/site boundaries.
+
+## Ledger/Governance Impact
+
+- Adds full vertical evidence chain from intake to approval and ERP draft update.
+- Maintains authority boundaries: recommendations and staging remain separate from final governance approvals.
+
+## Follow-Up Slices
+
+- Operational hardening slices (performance, backup/restore, disaster recovery).
+- Additional vertical module slices (restaurant/POS, light manufacturing, service ops).


### PR DESCRIPTION
## Description of Changes

Adds planning slices for the `b2b-institutional-memory-erpnext-architecture` workstream.

Included:
- New roadmap slices 25-32 in `docs/roadmap/slices/`
- Roadmap index updates in `docs/roadmap/README.md`
- Manifest updates in `docs/MANIFEST.yaml`

Planning constraints explicitly captured:
- ERPNext as source of record
- Lumina as semantic memory / decision precedent / escalation / bounded tool layer
- organization/site/actor-scoped institutional memory
- local-first single-box deployment
- API-first ERP adapters
- no credentials in prompts
- no raw transcript persistence required for institutional memory
- deterministic fake-fixture tests before live integration

## Type of Change

- [x] Documentation
- [ ] Core Engine
- [ ] Domain Pack
- [ ] Tool Adapter
- [ ] Governance/Security

## Validation

Focused checks passed locally:
- `tests/test_schema_versioning.py::TestManifestCoverage::test_all_docs_tracked`
- `tests/test_schema_versioning.py::TestManifestCoverage::test_no_pending_hashes`
- `tests/test_system_log_integrity.py::TestManifestIntegrity::test_manifest_check_passes`