### PR TITLE
feat: complete Slice 27 institutional memory layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,4 @@ pytest_log2.txt
 install_providers_log.txt
 aftman.toml
 default.project.json
+lumina-framework.code-workspace

--- a/docs/7-concepts/README.md
+++ b/docs/7-concepts/README.md
@@ -1,13 +1,13 @@
 ---
-version: 1.3.0
-last_updated: 2026-05-07
+version: 1.5.0
+last_updated: 2026-07-19
 ---
 
 # Section 7 — Concepts
 
-**Version:** 1.3.0
+**Version:** 1.5.0
 **Status:** Active
-**Last updated:** 2026-05-07
+**Last updated:** 2026-07-19
 
 ---
 
@@ -20,6 +20,7 @@ This section is Lumina's architectural rationale layer. It explains *why* scoped
 - [`prompt-packet-assembly(7)`](prompt-packet-assembly.md) — runtime pipeline that assembles task-complete context packets
 - [`domain-pack-anatomy(7)`](domain-pack-anatomy.md) — model-pack structure and isolation boundaries
 - [`edge-vectorization(7)`](edge-vectorization.md) — per-domain retrieval isolation and scoped context delivery
+- [`institutional-vector-memory(7)`](institutional-vector-memory.md) — scoped, transcript-free operational recall
 
 ## Reading paths
 
@@ -35,6 +36,8 @@ This section is Lumina's architectural rationale layer. It explains *why* scoped
 
 - **Retrieval + scoped-context path**
   - [`edge-vectorization.md`](edge-vectorization.md)
+  - [`identity-and-scoped-memory.md`](identity-and-scoped-memory.md)
+  - [`institutional-vector-memory.md`](institutional-vector-memory.md)
   - [`rag-contracts.md`](rag-contracts.md)
   - [`slm-compute-distribution.md`](slm-compute-distribution.md)
 

--- a/docs/7-concepts/institutional-vector-memory.md
+++ b/docs/7-concepts/institutional-vector-memory.md
@@ -1,0 +1,70 @@
+---
+version: 1.0.0
+last_updated: 2026-07-19
+---
+
+# Institutional Vector Memory
+
+Slice 27 adds a local-first institutional-memory retrieval layer over the
+existing vector store. It indexes concise institutional records rather than raw
+chat transcripts, so operational continuity can survive session boundaries
+without making transcript retention a prerequisite.
+
+## Record And Scope Boundary
+
+The indexer accepts the Slice 26 provider-neutral record families:
+
+- institutional memory records;
+- decision precedent records;
+- thread summary records; and
+- business-system event mirror records.
+
+Every indexed record requires `organization_id`, `site_id`, and `actor_id`.
+Institutional search requires `organization_id`, `site_id`, and
+`institutional_only=true`. The store first excludes nonmatching scope and
+non-institutional chunks, then ranks only eligible vectors. Optional actor,
+device, module, provider, and external-record filters further narrow the
+eligible corpus.
+
+This ordering is a security boundary: similarity ranking must never make an
+out-of-scope record eligible for recall.
+
+## Ingestion Lifecycle
+
+1. Validate the scoped record identity and derive its summary text.
+2. Convert the record to a `DocChunk` with institutional provenance metadata.
+3. Create a deterministic content identity from organization, site, record
+   type, record ID, and summary.
+4. Skip an already-indexed identity; otherwise embed and persist the new chunk.
+5. Reload persisted metadata before retrieval so local process restarts do not
+   change recall behavior.
+
+The stable identity permits repeated ingestion of one record while preserving
+separate records that happen to have identical summaries in another scope.
+
+## Local Backend Portability
+
+`InstitutionalMemoryIndexer` depends on the `InstitutionalMemoryStore` protocol:
+load, save, hash lookup, add, size, and filter-aware search. `VectorStore` is
+the initial flat-file implementation (`vectors.npz` plus `metadata.json`). A
+future local SQLite or vector engine backend can implement that protocol without
+changing record ingestion or retrieval-filter callers.
+
+Slice 27 deliberately does not require an ANN service, a hosted vector
+dependency, or a live business-system connector. Backend replacement and
+connector lifecycle work remain later slices.
+
+## Deterministic Recall Fixture
+
+`tests/artifacts/institutional-memory-recall-fixture.json` holds a synthetic
+brake-procedure query with same-site distractor and cross-site lookalike records.
+The focused test verifies that fixed embeddings return the expected local
+precedent and never retrieve the cross-site lookalike. This fixture is a
+repeatable recall-quality baseline, not a production corpus.
+
+## Governance Posture
+
+Retrieved records are advisory evidence. They retain artifact identity and
+scope provenance but do not grant authority, bypass policy gates, or trigger
+external mutations. Slice 28 consumes this layer for thread routing; Slice 29
+uses it for confidence and escalation decisions.

--- a/docs/MANIFEST.yaml
+++ b/docs/MANIFEST.yaml
@@ -1,5 +1,5 @@
 schema_version: 1.0.0
-last_updated: 2026-07-15
+last_updated: 2026-07-19
 artifacts:
 - path: docs/5-standards/manifest-regen-policy.md
   type: doc
@@ -124,9 +124,9 @@ artifacts:
   type: doc
   section: 0
   doc_version: 1.0.0
-  status: planned
-  last_updated: 2026-07-11
-  sha256: a06cd3055f704efb331ad3e4fe5aadb2c18b87e0fd8cae54a0500f0234ca37ae
+  status: delivered
+  last_updated: 2026-07-19
+  sha256: 6776e3b50464b33879ea74b2a6003042487597bdcf8c00dbb0f2bccb6aebc626
 - path: docs/roadmap/slices/28-semantic-thread-routing-and-forking.md
   type: doc
   section: 0
@@ -384,8 +384,8 @@ artifacts:
   section: 7
   doc_version: 1.5.0
   status: active
-  last_updated: 2026-04-16
-  sha256: 760169b81def1d53e2e6a16794c3b7c7d68b988c27314a2d91806e925e9e4743
+  last_updated: 2026-07-19
+  sha256: 1f0f420c2675be57aa256bccd311a956d74ef91f79d6641684a0425674c15761
 - path: docs/7-concepts/ai-governance-principles.md
   type: doc
   section: 7
@@ -838,6 +838,13 @@ artifacts:
   status: active
   last_updated: 2026-03-02
   sha256: 65add1e5e81eb427795d2ad02d0785847fc21dbe0269e9674f3301f815970b12
+- path: docs/7-concepts/institutional-vector-memory.md
+  type: doc
+  section: 7
+  doc_version: 1.0.0
+  status: active
+  last_updated: 2026-07-19
+  sha256: 001031e1152b5c62eefbffd66595ca0b8cc1808112bd1f4ed47e403f5f5f09de
 - path: docs/8-admin/domain-authority-roles.md
   type: doc
   section: 8
@@ -1980,8 +1987,8 @@ artifacts:
   type: doc
   doc_version: 1.0.0
   status: active
-  last_updated: 2026-06-18
-  sha256: fcdad3cffe06b8c09ea17f417487280c2e9f5040f9f6c2a419f037c64c6609f8
+  last_updated: 2026-07-19
+  sha256: e5fa69a75ef53ff1977dcaf403338a2c8bfb431cc95fb786caceea12cc8f6cfe
 - path: docs/roadmap/slices/01-framework-boundary.md
   type: doc
   doc_version: 1.0.0

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -52,7 +52,7 @@ under `docs/roadmap/slices/` and delivered as a focused PR.
 | [24](slices/24-system-led-evidence-commit-and-teardown-confirmation.md) | System-Led Evidence Commit and Teardown Confirmation | Delivered |
 | [25](slices/25-b2b-workstream-boundary-and-task-graph.md) | B2B Workstream Boundary and Global Task Graph | Planned |
 | [26](slices/26-tenant-site-actor-memory-contracts.md) | Tenant/Site/Actor Memory Contracts | Delivered |
-| [27](slices/27-institutional-vector-memory-layer.md) | Institutional Vector Memory Layer | Planned |
+| [27](slices/27-institutional-vector-memory-layer.md) | Institutional Vector Memory Layer | Delivered |
 | [28](slices/28-semantic-thread-routing-and-forking.md) | Semantic Thread Routing and Context Forking | Planned |
 | [29](slices/29-decision-precedent-confidence-and-escalation.md) | Decision Precedent, Confidence, and Escalation | Planned |
 | [30](slices/30-erpnext-adapter-foundation-and-fixtures.md) | Canonical Business-System Contracts and Capability Taxonomy | Planned |

--- a/docs/roadmap/slices/27-institutional-vector-memory-layer.md
+++ b/docs/roadmap/slices/27-institutional-vector-memory-layer.md
@@ -1,9 +1,9 @@
 ---
 title: "Slice 27 — Institutional Vector Memory Layer"
 slice: 27
-status: planned
-version: 0.1.0
-last_updated: 2026-07-11
+status: delivered
+version: 1.0.0
+last_updated: 2026-07-19
 ---
 
 ## Purpose
@@ -28,6 +28,17 @@ Extend the existing retrieval stack into a tenant/site/actor-scoped institutiona
 - Add retrieval subsystem design docs for scoped institutional indexing.
 - Add interface updates for scoped store registry and filter-aware search.
 - Add deterministic benchmark fixtures for memory recall quality.
+
+## Delivered Implementation
+
+- Added `RetrievalFilter` and `InstitutionalMemoryStore` contracts for scoped,
+  backend-portable local retrieval.
+- Added transcript-free conversion and incremental ingestion for the Slice 26
+  record families, with scope- and record-aware content identity.
+- Extended flat-file vector metadata and pre-score filtering for institutional
+  provenance and optional metadata constraints.
+- Added deterministic isolation, deduplication, and recall-fixture tests.
+- Added the institutional vector-memory design and lifecycle note.
 
 ## New/Changed Contracts
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,7 @@ aiosqlite>=0.20.0
 httpx>=0.27.0
 bcrypt>=4.0.0
 argon2-cffi>=23.1.0
+ruff>=0.15.0
 
 # Add low-level binary/runtime deps required by test collection
 pydantic-core>=2.46.4

--- a/src/lumina/core/nlp.py
+++ b/src/lumina/core/nlp.py
@@ -18,6 +18,8 @@ import logging
 import re
 from typing import Any
 
+from lumina.retrieval.contracts import RetrievalFilter
+
 log = logging.getLogger("lumina.core-nlp")
 
 # ── Lazy spaCy loader ────────────────────────────────────────
@@ -301,6 +303,7 @@ def search_domain(
     site_id: str | None = None,
     actor_id: str | None = None,
     device_id: str | None = None,
+    retrieval_filter: RetrievalFilter | None = None,
 ) -> list[Any]:
     """Search the per-domain vector store for *text*.
 
@@ -322,4 +325,5 @@ def search_domain(
         site_id=site_id,
         actor_id=actor_id,
         device_id=device_id,
+        retrieval_filter=retrieval_filter,
     )

--- a/src/lumina/retrieval/contracts.py
+++ b/src/lumina/retrieval/contracts.py
@@ -1,0 +1,39 @@
+"""Provider-neutral contracts for scoped institutional retrieval."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RetrievalFilter:
+    """Hard and optional metadata filters applied before vector scoring."""
+
+    organization_id: str | None = None
+    site_id: str | None = None
+    actor_id: str | None = None
+    device_id: str | None = None
+    module_key: str | None = None
+    provider: str | None = None
+    external_record_type: str | None = None
+    external_record_id: str | None = None
+    institutional_only: bool = False
+
+    def validate(self) -> None:
+        """Reject incomplete filters for institutional-memory searches."""
+        if self.institutional_only and not self.organization_id:
+            raise ValueError("institutional retrieval requires organization_id")
+        if self.institutional_only and not self.site_id:
+            raise ValueError("institutional retrieval requires site_id")
+
+    def as_metadata(self) -> dict[str, str | None]:
+        """Return the chunk metadata keys controlled by this filter."""
+        return {
+            "organization_id": self.organization_id,
+            "site_id": self.site_id,
+            "actor_id": self.actor_id,
+            "device_id": self.device_id,
+            "module_key": self.module_key,
+            "provider": self.provider,
+            "external_record_type": self.external_record_type,
+            "external_record_id": self.external_record_id,
+        }

--- a/src/lumina/retrieval/contracts.py
+++ b/src/lumina/retrieval/contracts.py
@@ -2,6 +2,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    import numpy as np
+    from numpy.typing import NDArray
+
+    from lumina.retrieval.embedder import DocChunk
+    from lumina.retrieval.vector_store import SearchResult
 
 
 @dataclass(frozen=True)
@@ -37,3 +45,26 @@ class RetrievalFilter:
             "external_record_type": self.external_record_type,
             "external_record_id": self.external_record_id,
         }
+
+
+class InstitutionalMemoryStore(Protocol):
+    """Portable local-store contract consumed by institutional-memory indexing."""
+
+    @property
+    def size(self) -> int: ...
+
+    def has_hash(self, content_hash: str) -> bool: ...
+
+    def add(self, chunks: list[DocChunk], vectors: NDArray[np.float32]) -> None: ...
+
+    def save(self) -> None: ...
+
+    def load(self) -> None: ...
+
+    def search(
+        self,
+        query_vec: NDArray[np.float32],
+        k: int = 5,
+        *,
+        retrieval_filter: RetrievalFilter | None = None,
+    ) -> list[SearchResult]: ...

--- a/src/lumina/retrieval/embedder.py
+++ b/src/lumina/retrieval/embedder.py
@@ -15,7 +15,6 @@ import json
 import logging
 import re
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -41,6 +40,11 @@ class DocChunk:
     site_id: str | None = field(default=None, repr=False)
     actor_id: str | None = field(default=None, repr=False)
     device_id: str | None = field(default=None, repr=False)
+    record_id: str | None = field(default=None, repr=False)
+    provider: str | None = field(default=None, repr=False)
+    external_record_type: str | None = field(default=None, repr=False)
+    external_record_id: str | None = field(default=None, repr=False)
+    module_key: str | None = field(default=None, repr=False)
 
     @staticmethod
     def compute_hash(text: str) -> str:

--- a/src/lumina/retrieval/institutional.py
+++ b/src/lumina/retrieval/institutional.py
@@ -1,0 +1,134 @@
+"""Local-first ingestion of Slice 26 institutional memory records."""
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from typing import Any
+
+from lumina.retrieval.embedder import DocChunk, DocEmbedder
+from lumina.retrieval.vector_store import SearchResult, VectorStore
+
+_RECORD_SUMMARY_FIELDS = (
+    "summary",
+    "decision_summary",
+    "event_type",
+)
+
+
+def _required_identifier(record: dict[str, Any], field_name: str) -> str:
+    value = record.get(field_name)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"institutional record requires {field_name}")
+    return value.strip()
+
+
+def _summary_text(record: dict[str, Any]) -> str:
+    for field_name in _RECORD_SUMMARY_FIELDS:
+        value = record.get(field_name)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    raise ValueError("institutional record requires a summary field")
+
+
+def _metadata(record: dict[str, Any]) -> dict[str, str | None]:
+    reference = record.get("external_system_reference")
+    reference = reference if isinstance(reference, dict) else {}
+    provider_data = reference.get("provider_data")
+    provider_data = provider_data if isinstance(provider_data, dict) else {}
+    return {
+        "record_id": record.get("record_id"),
+        "provider": provider_data.get("provider"),
+        "external_record_type": reference.get("external_record_type"),
+        "external_record_id": reference.get("external_record_id"),
+        "module_key": record.get("module_key"),
+    }
+
+
+def record_to_chunk(record: dict[str, Any]) -> DocChunk:
+    """Convert one scoped memory record into a deterministic index chunk."""
+    record_type = _required_identifier(record, "record_type")
+    record_id = _required_identifier(record, "record_id")
+    organization_id = _required_identifier(record, "organization_id")
+    site_id = _required_identifier(record, "site_id")
+    actor_id = _required_identifier(record, "actor_id")
+    summary = _summary_text(record)
+    content = f"{record_type}\n{summary}"
+    metadata = _metadata(record)
+
+    return DocChunk(
+        source_path=f"institutional://{record_id}",
+        heading=record_type,
+        text=summary,
+        content_hash=DocChunk.compute_hash(content),
+        content_type="institutional_memory",
+        domain_id=str(record.get("domain_id") or ""),
+        organization_id=organization_id,
+        site_id=site_id,
+        actor_id=actor_id,
+        device_id=record.get("device_id") if isinstance(record.get("device_id"), str) else None,
+        record_id=record_id,
+        provider=metadata["provider"],
+        external_record_type=metadata["external_record_type"],
+        external_record_id=metadata["external_record_id"],
+        module_key=metadata["module_key"],
+    )
+
+
+class InstitutionalMemoryIndexer:
+    """Embed and persist scoped memory records using the current local store."""
+
+    def __init__(self, store: VectorStore, embedder: DocEmbedder) -> None:
+        self._store = store
+        self._embedder = embedder
+
+    def ingest(self, records: Iterable[dict[str, Any]]) -> dict[str, int]:
+        """Index new records and return deterministic ingestion counts."""
+        new_chunks: list[DocChunk] = []
+        skipped = 0
+        for record in records:
+            chunk = record_to_chunk(record)
+            if self._store.has_hash(chunk.content_hash):
+                skipped += 1
+            else:
+                new_chunks.append(chunk)
+
+        if new_chunks:
+            vectors = self._embedder.embed_chunks(new_chunks)
+            self._store.add(new_chunks, vectors)
+            self._store.save()
+
+        return {
+            "records_seen": skipped + len(new_chunks),
+            "records_indexed": len(new_chunks),
+            "records_skipped": skipped,
+        }
+
+    def search(
+        self,
+        query: str,
+        retrieval_filter,
+        *,
+        k: int = 5,
+    ) -> list[SearchResult]:
+        """Search institutional memory with mandatory hard scope filters."""
+        retrieval_filter.validate()
+        if not retrieval_filter.institutional_only:
+            raise ValueError("institutional search requires institutional_only")
+        self._store.load()
+        if self._store.size == 0:
+            return []
+        return self._store.search(
+            self._embedder.embed_query(query),
+            k=k,
+            retrieval_filter=retrieval_filter,
+        )
+
+    @staticmethod
+    def canonical_content(record: dict[str, Any]) -> str:
+        """Return the stable content payload used for deterministic inspection."""
+        return json.dumps(
+            {"record_type": record.get("record_type"), "summary": _summary_text(record)},
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )

--- a/src/lumina/retrieval/institutional.py
+++ b/src/lumina/retrieval/institutional.py
@@ -1,4 +1,4 @@
-"""Local-first ingestion of Slice 26 institutional memory records."""
+"""Local-first Slice 27 ingestion of the Slice 26 institutional record families."""
 from __future__ import annotations
 
 import json

--- a/src/lumina/retrieval/institutional.py
+++ b/src/lumina/retrieval/institutional.py
@@ -6,7 +6,8 @@ from collections.abc import Iterable
 from typing import Any
 
 from lumina.retrieval.embedder import DocChunk, DocEmbedder
-from lumina.retrieval.vector_store import SearchResult, VectorStore
+from lumina.retrieval.contracts import InstitutionalMemoryStore, RetrievalFilter
+from lumina.retrieval.vector_store import SearchResult
 
 _RECORD_SUMMARY_FIELDS = (
     "summary",
@@ -52,7 +53,18 @@ def record_to_chunk(record: dict[str, Any]) -> DocChunk:
     site_id = _required_identifier(record, "site_id")
     actor_id = _required_identifier(record, "actor_id")
     summary = _summary_text(record)
-    content = f"{record_type}\n{summary}"
+    content = json.dumps(
+        {
+            "organization_id": organization_id,
+            "site_id": site_id,
+            "record_type": record_type,
+            "record_id": record_id,
+            "summary": summary,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
     metadata = _metadata(record)
 
     return DocChunk(
@@ -77,7 +89,7 @@ def record_to_chunk(record: dict[str, Any]) -> DocChunk:
 class InstitutionalMemoryIndexer:
     """Embed and persist scoped memory records using the current local store."""
 
-    def __init__(self, store: VectorStore, embedder: DocEmbedder) -> None:
+    def __init__(self, store: InstitutionalMemoryStore, embedder: DocEmbedder) -> None:
         self._store = store
         self._embedder = embedder
 
@@ -106,7 +118,7 @@ class InstitutionalMemoryIndexer:
     def search(
         self,
         query: str,
-        retrieval_filter,
+        retrieval_filter: RetrievalFilter,
         *,
         k: int = 5,
     ) -> list[SearchResult]:
@@ -127,7 +139,13 @@ class InstitutionalMemoryIndexer:
     def canonical_content(record: dict[str, Any]) -> str:
         """Return the stable content payload used for deterministic inspection."""
         return json.dumps(
-            {"record_type": record.get("record_type"), "summary": _summary_text(record)},
+            {
+                "organization_id": record.get("organization_id"),
+                "site_id": record.get("site_id"),
+                "record_type": record.get("record_type"),
+                "record_id": record.get("record_id"),
+                "summary": _summary_text(record),
+            },
             sort_keys=True,
             separators=(",", ":"),
             ensure_ascii=False,

--- a/src/lumina/retrieval/vector_store.py
+++ b/src/lumina/retrieval/vector_store.py
@@ -113,9 +113,13 @@ class VectorStore:
         eligible_indices = [
             index
             for index, chunk in enumerate(self._chunks)
-            if all(
-                expected is None or getattr(chunk, field_name, None) == expected
-                for field_name, expected in filters.items()
+            if (
+                (not retrieval_filter or not retrieval_filter.institutional_only
+                 or chunk.content_type == "institutional_memory")
+                and all(
+                    expected is None or getattr(chunk, field_name, None) == expected
+                    for field_name, expected in filters.items()
+                )
             )
         ]
         if not eligible_indices:

--- a/src/lumina/retrieval/vector_store.py
+++ b/src/lumina/retrieval/vector_store.py
@@ -90,11 +90,6 @@ class VectorStore:
         """Return top-*k* chunks, applying scope filters before ranking."""
         if retrieval_filter is not None:
             retrieval_filter.validate()
-            metadata_filters = retrieval_filter.as_metadata()
-            organization_id = metadata_filters["organization_id"]
-            site_id = metadata_filters["site_id"]
-            actor_id = metadata_filters["actor_id"]
-            device_id = metadata_filters["device_id"]
         if self._vectors.size == 0:
             return []
 
@@ -108,7 +103,7 @@ class VectorStore:
             filters.update({
                 key: value
                 for key, value in retrieval_filter.as_metadata().items()
-                if key not in filters
+                if value is not None and filters.get(key) is None
             })
         eligible_indices = [
             index

--- a/src/lumina/retrieval/vector_store.py
+++ b/src/lumina/retrieval/vector_store.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from lumina.retrieval.embedder import EMBEDDING_DIM, DocChunk
+from lumina.retrieval.contracts import RetrievalFilter
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -84,8 +85,16 @@ class VectorStore:
         site_id: str | None = None,
         actor_id: str | None = None,
         device_id: str | None = None,
+        retrieval_filter: RetrievalFilter | None = None,
     ) -> list[SearchResult]:
         """Return top-*k* chunks, applying scope filters before ranking."""
+        if retrieval_filter is not None:
+            retrieval_filter.validate()
+            metadata_filters = retrieval_filter.as_metadata()
+            organization_id = metadata_filters["organization_id"]
+            site_id = metadata_filters["site_id"]
+            actor_id = metadata_filters["actor_id"]
+            device_id = metadata_filters["device_id"]
         if self._vectors.size == 0:
             return []
 
@@ -95,6 +104,12 @@ class VectorStore:
             "actor_id": actor_id,
             "device_id": device_id,
         }
+        if retrieval_filter is not None:
+            filters.update({
+                key: value
+                for key, value in retrieval_filter.as_metadata().items()
+                if key not in filters
+            })
         eligible_indices = [
             index
             for index, chunk in enumerate(self._chunks)
@@ -160,6 +175,11 @@ class VectorStore:
                 site_id=r.get("site_id"),
                 actor_id=r.get("actor_id"),
                 device_id=r.get("device_id"),
+                record_id=r.get("record_id"),
+                provider=r.get("provider"),
+                external_record_type=r.get("external_record_type"),
+                external_record_id=r.get("external_record_id"),
+                module_key=r.get("module_key"),
             )
             for r in raw
         ]

--- a/tests/artifacts/institutional-memory-recall-fixture.json
+++ b/tests/artifacts/institutional-memory-recall-fixture.json
@@ -1,0 +1,38 @@
+{
+  "query": "brake inspection procedure",
+  "k": 1,
+  "filter": {
+    "organization_id": "org-a",
+    "site_id": "site-1",
+    "institutional_only": true
+  },
+  "records": [
+    {
+      "record_type": "DecisionPrecedentRecord",
+      "record_id": "precedent-a",
+      "organization_id": "org-a",
+      "site_id": "site-1",
+      "actor_id": "actor-1",
+      "decision_summary": "Use the approved brake inspection procedure.",
+      "outcome": "successful"
+    },
+    {
+      "record_type": "InstitutionalMemoryRecord",
+      "record_id": "memory-a",
+      "organization_id": "org-a",
+      "site_id": "site-1",
+      "actor_id": "actor-1",
+      "summary": "The oil-change checklist is complete."
+    },
+    {
+      "record_type": "DecisionPrecedentRecord",
+      "record_id": "precedent-b",
+      "organization_id": "org-b",
+      "site_id": "site-2",
+      "actor_id": "actor-2",
+      "decision_summary": "Use the approved brake inspection procedure.",
+      "outcome": "successful"
+    }
+  ],
+  "expected_record_ids": ["precedent-a"]
+}

--- a/tests/test_institutional_memory.py
+++ b/tests/test_institutional_memory.py
@@ -1,12 +1,17 @@
 """Tests for local-first institutional memory ingestion."""
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import numpy as np
 import pytest
 
 from lumina.retrieval.embedder import EMBEDDING_DIM
 from lumina.retrieval.institutional import InstitutionalMemoryIndexer, record_to_chunk
 from lumina.retrieval.vector_store import VectorStore
+
+FIXTURE_PATH = Path(__file__).parent / "artifacts" / "institutional-memory-recall-fixture.json"
 
 
 class _FakeEmbedder:
@@ -15,6 +20,20 @@ class _FakeEmbedder:
 
     def embed_query(self, query):
         return np.ones(EMBEDDING_DIM, dtype=np.float32)
+
+
+class _FixtureEmbedder:
+    @staticmethod
+    def _embed(text: str) -> np.ndarray:
+        vector = np.zeros(EMBEDDING_DIM, dtype=np.float32)
+        vector[0 if "brake" in text.lower() else 1] = 1.0
+        return vector
+
+    def embed_chunks(self, chunks):
+        return np.asarray([self._embed(chunk.text) for chunk in chunks], dtype=np.float32)
+
+    def embed_query(self, query):
+        return self._embed(query)
 
 
 def _record(record_id: str = "memory-1") -> dict:
@@ -61,6 +80,19 @@ def test_indexer_deduplicates_by_content_hash(tmp_path) -> None:
     assert store.size == 1
 
 
+def test_indexer_keeps_distinct_records_with_matching_summaries(tmp_path) -> None:
+    store = VectorStore(tmp_path / "vs")
+    indexer = InstitutionalMemoryIndexer(store, _FakeEmbedder())
+    other_record = _record("memory-2")
+    other_record["organization_id"] = "org-b"
+    other_record["site_id"] = "site-2"
+
+    result = indexer.ingest([_record(), other_record])
+
+    assert result == {"records_seen": 2, "records_indexed": 2, "records_skipped": 0}
+    assert store.size == 2
+
+
 def test_indexer_accepts_transcript_free_decision_record(tmp_path) -> None:
     record = _record("decision-1")
     record.pop("thread_id")
@@ -98,6 +130,55 @@ def test_indexer_search_requires_hard_scope(tmp_path) -> None:
             "maintenance",
             RetrievalFilter(organization_id="org-a", site_id="site-1"),
         )
+
+
+def test_indexer_search_excludes_scoped_non_institutional_chunks(tmp_path) -> None:
+    from lumina.retrieval.contracts import RetrievalFilter
+    from lumina.retrieval.embedder import DocChunk
+
+    store = VectorStore(tmp_path / "vs")
+    store.add(
+        [
+            DocChunk(
+                source_path="domain.md",
+                heading="domain",
+                text="maintenance decision",
+                content_hash=DocChunk.compute_hash("domain"),
+                organization_id="org-a",
+                site_id="site-1",
+            ),
+        ],
+        np.ones((1, EMBEDDING_DIM), dtype=np.float32),
+    )
+    indexer = InstitutionalMemoryIndexer(store, _FakeEmbedder())
+    indexer.ingest([_record()])
+
+    results = indexer.search(
+        "maintenance",
+        RetrievalFilter(
+            organization_id="org-a",
+            site_id="site-1",
+            institutional_only=True,
+        ),
+    )
+
+    assert [result.chunk.content_type for result in results] == ["institutional_memory"]
+
+
+def test_recall_fixture_returns_only_the_scoped_expected_precedent(tmp_path) -> None:
+    from lumina.retrieval.contracts import RetrievalFilter
+
+    fixture = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    indexer = InstitutionalMemoryIndexer(VectorStore(tmp_path / "vs"), _FixtureEmbedder())
+    indexer.ingest(fixture["records"])
+
+    results = indexer.search(
+        fixture["query"],
+        RetrievalFilter(**fixture["filter"]),
+        k=fixture["k"],
+    )
+
+    assert [result.chunk.record_id for result in results] == fixture["expected_record_ids"]
 
 
 @pytest.mark.parametrize("field", ["organization_id", "site_id", "actor_id"])

--- a/tests/test_institutional_memory.py
+++ b/tests/test_institutional_memory.py
@@ -1,0 +1,115 @@
+"""Tests for local-first institutional memory ingestion."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from lumina.retrieval.embedder import EMBEDDING_DIM
+from lumina.retrieval.institutional import InstitutionalMemoryIndexer, record_to_chunk
+from lumina.retrieval.vector_store import VectorStore
+
+
+class _FakeEmbedder:
+    def embed_chunks(self, chunks):
+        return np.ones((len(chunks), EMBEDDING_DIM), dtype=np.float32)
+
+    def embed_query(self, query):
+        return np.ones(EMBEDDING_DIM, dtype=np.float32)
+
+
+def _record(record_id: str = "memory-1") -> dict:
+    return {
+        "record_type": "ThreadSummaryRecord",
+        "record_id": record_id,
+        "organization_id": "org-a",
+        "site_id": "site-1",
+        "actor_id": "actor-1",
+        "thread_id": "thread-1",
+        "summary": "The maintenance decision was resolved.",
+        "status": "resolved",
+        "created_utc": "2026-07-16T12:00:00Z",
+        "external_system_reference": {
+            "connector_instance_id": "connector-1",
+            "external_record_type": "work_order",
+            "external_record_id": "wo-1",
+            "provider_data": {"provider": "erp"},
+        },
+    }
+
+
+def test_record_to_chunk_preserves_scope_and_provenance() -> None:
+    chunk = record_to_chunk(_record())
+    assert chunk.content_type == "institutional_memory"
+    assert chunk.organization_id == "org-a"
+    assert chunk.site_id == "site-1"
+    assert chunk.actor_id == "actor-1"
+    assert chunk.record_id == "memory-1"
+    assert chunk.provider == "erp"
+    assert chunk.external_record_id == "wo-1"
+    assert chunk.content_hash == record_to_chunk(_record()).content_hash
+
+
+def test_indexer_deduplicates_by_content_hash(tmp_path) -> None:
+    store = VectorStore(tmp_path / "vs")
+    indexer = InstitutionalMemoryIndexer(store, _FakeEmbedder())
+
+    first = indexer.ingest([_record()])
+    second = indexer.ingest([_record()])
+
+    assert first == {"records_seen": 1, "records_indexed": 1, "records_skipped": 0}
+    assert second == {"records_seen": 1, "records_indexed": 0, "records_skipped": 1}
+    assert store.size == 1
+
+
+def test_indexer_accepts_transcript_free_decision_record(tmp_path) -> None:
+    record = _record("decision-1")
+    record.pop("thread_id")
+    record["record_type"] = "DecisionPrecedentRecord"
+    record["decision_summary"] = record.pop("summary")
+    record["outcome"] = "successful"
+    store = VectorStore(tmp_path / "vs")
+
+    result = InstitutionalMemoryIndexer(store, _FakeEmbedder()).ingest([record])
+
+    assert result["records_indexed"] == 1
+    assert store._chunks[0].text == "The maintenance decision was resolved."
+
+
+def test_indexer_search_requires_hard_scope(tmp_path) -> None:
+    from lumina.retrieval.contracts import RetrievalFilter
+
+    indexer = InstitutionalMemoryIndexer(VectorStore(tmp_path / "vs"), _FakeEmbedder())
+    indexer.ingest([_record()])
+
+    results = indexer.search(
+        "maintenance",
+        RetrievalFilter(
+            organization_id="org-a",
+            site_id="site-1",
+            institutional_only=True,
+        ),
+    )
+
+    assert len(results) == 1
+    assert results[0].chunk.record_id == "memory-1"
+
+    with pytest.raises(ValueError, match="institutional_only"):
+        indexer.search(
+            "maintenance",
+            RetrievalFilter(organization_id="org-a", site_id="site-1"),
+        )
+
+
+@pytest.mark.parametrize("field", ["organization_id", "site_id", "actor_id"])
+def test_record_to_chunk_requires_scope(field: str) -> None:
+    record = _record()
+    record.pop(field)
+    with pytest.raises(ValueError, match=field):
+        record_to_chunk(record)
+
+
+def test_record_to_chunk_requires_summary() -> None:
+    record = _record()
+    record.pop("summary")
+    with pytest.raises(ValueError, match="summary"):
+        record_to_chunk(record)

--- a/tests/test_nlp.py
+++ b/tests/test_nlp.py
@@ -10,6 +10,7 @@ from lumina.core.nlp import (
     split_sentences,
     tokenize,
 )
+from lumina.retrieval.contracts import RetrievalFilter
 
 
 # ── get_nlp ────────────────────────────────────────────────────────────────────
@@ -244,3 +245,41 @@ def test_classify_domain_confidence_scaled_up() -> None:
     result = classify_domain("algebra equation solve variable something", domain_map)
     assert result is not None
     assert result["confidence"] <= 1.0
+
+
+@pytest.mark.unit
+def test_search_domain_accepts_typed_retrieval_filter(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Store:
+        size = 1
+
+        def search(self, query_vec, *, k, organization_id, site_id, actor_id, device_id, retrieval_filter):
+            assert retrieval_filter == RetrievalFilter(
+                organization_id="org-a",
+                site_id="site-1",
+                institutional_only=True,
+            )
+            assert organization_id is None
+            assert site_id is None
+            return ["hit"]
+
+    class _Registry:
+        def get(self, domain_id):
+            assert domain_id == "education"
+            return _Store()
+
+    class _Embedder:
+        def embed_query(self, text):
+            return [1.0]
+
+    monkeypatch.setattr(nlp_mod, "_vector_registry", _Registry())
+    monkeypatch.setattr(nlp_mod, "_doc_embedder", _Embedder())
+
+    assert nlp_mod.search_domain(
+        "maintenance decision",
+        "education",
+        retrieval_filter=RetrievalFilter(
+            organization_id="org-a",
+            site_id="site-1",
+            institutional_only=True,
+        ),
+    ) == ["hit"]

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -353,12 +353,14 @@ class TestVectorStore:
         chunks = [
             DocChunk(
                 "precedent-a.json", "summary", "allowed", DocChunk.compute_hash("allowed"),
+                content_type="institutional_memory",
                 organization_id="org-a", site_id="site-1", actor_id="actor-1",
                 provider="erp", external_record_type="work_order",
                 external_record_id="wo-1", module_key="ops",
             ),
             DocChunk(
                 "precedent-b.json", "summary", "excluded", DocChunk.compute_hash("excluded"),
+                content_type="institutional_memory",
                 organization_id="org-a", site_id="site-1", actor_id="actor-2",
                 provider="erp", external_record_type="work_order",
                 external_record_id="wo-2", module_key="ops",

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import textwrap
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -12,13 +11,13 @@ import pytest
 
 from lumina.retrieval.embedder import (
     EMBEDDING_DIM,
-    PROVIDER_OLLAMA,
     PROVIDER_SENTENCE_TRANSFORMERS,
     DocChunk,
     DocEmbedder,
     chunk_markdown,
 )
 from lumina.retrieval.vector_store import SearchResult, VectorStore, VectorStoreRegistry
+from lumina.retrieval.contracts import RetrievalFilter
 from lumina.retrieval.housekeeper import (
     Housekeeper,
     collect_md_files,
@@ -348,6 +347,61 @@ class TestVectorStore:
             organization_id="org-a",
             site_id="site-1",
         ) == []
+
+    def test_search_retrieval_filter_applies_optional_institutional_metadata(self, tmp_path):
+        store = VectorStore(tmp_path / "vs")
+        chunks = [
+            DocChunk(
+                "precedent-a.json", "summary", "allowed", DocChunk.compute_hash("allowed"),
+                organization_id="org-a", site_id="site-1", actor_id="actor-1",
+                provider="erp", external_record_type="work_order",
+                external_record_id="wo-1", module_key="ops",
+            ),
+            DocChunk(
+                "precedent-b.json", "summary", "excluded", DocChunk.compute_hash("excluded"),
+                organization_id="org-a", site_id="site-1", actor_id="actor-2",
+                provider="erp", external_record_type="work_order",
+                external_record_id="wo-2", module_key="ops",
+            ),
+        ]
+        vectors = np.zeros((2, EMBEDDING_DIM), dtype=np.float32)
+        vectors[:, 0] = 1.0
+        store.add(chunks, vectors)
+
+        results = store.search(
+            vectors[0],
+            k=5,
+            retrieval_filter=RetrievalFilter(
+                organization_id="org-a",
+                site_id="site-1",
+                actor_id="actor-1",
+                module_key="ops",
+                provider="erp",
+                external_record_type="work_order",
+                external_record_id="wo-1",
+                institutional_only=True,
+            ),
+        )
+
+        assert [result.chunk.text for result in results] == ["allowed"]
+
+    def test_institutional_retrieval_filter_requires_organization_and_site(self, tmp_path):
+        store = VectorStore(tmp_path / "vs")
+        vector = np.zeros((1, EMBEDDING_DIM), dtype=np.float32)
+        with pytest.raises(ValueError, match="requires organization_id"):
+            store.search(
+                vector[0],
+                retrieval_filter=RetrievalFilter(institutional_only=True),
+            )
+
+        with pytest.raises(ValueError, match="requires site_id"):
+            store.search(
+                vector[0],
+                retrieval_filter=RetrievalFilter(
+                    organization_id="org-a",
+                    institutional_only=True,
+                ),
+            )
 
     def test_save_load_roundtrip(self, tmp_path):
         store_dir = tmp_path / "vs"

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -405,6 +405,30 @@ class TestVectorStore:
                 ),
             )
 
+    def test_retrieval_filter_cannot_clear_keyword_scope(self, tmp_path):
+        store = VectorStore(tmp_path / "vs")
+        chunks = [
+            DocChunk(
+                "org-a.json", "summary", "allowed", DocChunk.compute_hash("allowed"),
+                organization_id="org-a", module_key="ops",
+            ),
+            DocChunk(
+                "org-b.json", "summary", "excluded", DocChunk.compute_hash("excluded"),
+                organization_id="org-b", module_key="ops",
+            ),
+        ]
+        vectors = np.zeros((2, EMBEDDING_DIM), dtype=np.float32)
+        vectors[:, 0] = 1.0
+        store.add(chunks, vectors)
+
+        results = store.search(
+            vectors[0],
+            organization_id="org-a",
+            retrieval_filter=RetrievalFilter(module_key="ops"),
+        )
+
+        assert [result.chunk.text for result in results] == ["allowed"]
+
     def test_save_load_roundtrip(self, tmp_path):
         store_dir = tmp_path / "vs"
         store = VectorStore(store_dir)


### PR DESCRIPTION
## Summary

Completes Slice 27 with a local-first, provider-neutral institutional memory retrieval layer. Institutional recall is now explicitly corpus-bound, scope-isolated before ranking, portable across local store implementations, and documented with deterministic fixture coverage.

## Changes

- Enforce `institutional_only` as a corpus boundary: non-institutional chunks are excluded before vector scoring.
- Preserve organization/site/record identity in institutional content hashes so identical summaries from distinct records or tenants do not collide during ingestion.
- Add the `InstitutionalMemoryStore` protocol for future local backend portability without changing indexer callers.
- Preserve typed hard organization/site filters and optional actor, device, module, provider, and external-record filters.
- Add deterministic ingestion, isolation, deduplication, and fixture-driven recall tests.
- Add the institutional vector-memory lifecycle and backend-portability concept note.
- Mark Slice 27 as delivered and regenerate documentation manifest hashes.
- Ignore the local `lumina-framework.code-workspace` file.

## Validation

- Focused retrieval suite: `91 passed`
- Schema, manifest, integrity, and memory-contract suite: `1193 passed`
- Full test suite: `5314 passed, 2 skipped`
- Ruff: passed
- `git diff --check`: passed

The full suite retains the existing FastAPI/httpx deprecation warning. Manifest integrity reports no missing or mismatched artifacts; the pre-existing pending hash for Slice 02 remains unchanged.

## Out Of Scope

- Connector adapters and live business-system integration
- Cloud-hosted vector services and ANN infrastructure
- Database migrations or backend replacement
- Thread routing, confidence scoring, authority, or policy changes (Slices 28-29)