### PR TITLE
Add scoped semantic thread routing

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,22 @@
+FROM python:3.13-slim
+
+WORKDIR /workspace
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y bash git \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python -m pip install --upgrade pip \
+    && python -m pip install --index-url https://download.pytorch.org/whl/cpu torch \
+    && python -m pip install \
+        fastapi uvicorn httpx python-multipart pyyaml \
+        openai anthropic \
+        'sqlalchemy[asyncio]' aiosqlite \
+        bcrypt argon2-cffi spacy sympy sentence-transformers caldav \
+        pytest pytest-cov jsonschema \
+    && python -m pip install --only-binary=:all: 'numpy>=1.26.0' \
+    && python -m spacy download en_core_web_sm

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,56 @@
+name: lumina-ci
+
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile.ci
+    image: lumina-ci-backend:local
+    working_dir: /workspace
+    volumes:
+      - type: bind
+        source: .
+        target: /workspace
+      - type: volume
+        source: backend-pytest-cache
+        target: /workspace/.pytest_cache
+    command: >
+      bash -lc "python -m pip install -e '.[providers,sqlite,passwords,nlp,math,retrieval,calendar,dev]'
+      && tr -d '\015' < scripts/check-local-secret-hygiene.sh | bash && python -m pytest tests -q
+      --cov=lumina --cov-report=term-missing --cov-fail-under=85"
+
+  frontend-unit:
+    image: node:20-bookworm
+    working_dir: /workspace/src/web
+    volumes:
+      - type: bind
+        source: .
+        target: /workspace
+      - type: volume
+        source: frontend-unit-node-modules
+        target: /workspace/src/web/node_modules
+      - type: volume
+        source: npm-cache
+        target: /root/.npm
+    command: bash -lc "npm ci && npm run test:unit"
+
+  frontend-e2e:
+    image: mcr.microsoft.com/playwright:v1.58.2-noble
+    working_dir: /workspace/src/web
+    volumes:
+      - type: bind
+        source: .
+        target: /workspace
+      - type: volume
+        source: frontend-e2e-node-modules
+        target: /workspace/src/web/node_modules
+      - type: volume
+        source: npm-cache
+        target: /root/.npm
+    command: bash -lc "npm ci && npm run test:e2e"
+
+volumes:
+  backend-pytest-cache:
+  frontend-unit-node-modules:
+  frontend-e2e-node-modules:
+  npm-cache:

--- a/docs/MANIFEST.yaml
+++ b/docs/MANIFEST.yaml
@@ -1,5 +1,5 @@
 schema_version: 1.0.0
-last_updated: 2026-07-19
+last_updated: 2026-07-20
 artifacts:
 - path: docs/5-standards/manifest-regen-policy.md
   type: doc
@@ -131,9 +131,9 @@ artifacts:
   type: doc
   section: 0
   doc_version: 1.0.0
-  status: planned
-  last_updated: 2026-07-11
-  sha256: 5bb3dca25408d17a6dd704a8a4e618da9dd3c49280d7233b21b41f72aabc9f2a
+  status: delivered
+  last_updated: 2026-07-20
+  sha256: 053a73f6f10a9431e845b2d20f383fec5151dd0cc3317f6855f41bbfdbf8a91e
 - path: docs/roadmap/slices/29-decision-precedent-confidence-and-escalation.md
   type: doc
   section: 0
@@ -1022,6 +1022,24 @@ artifacts:
   status: active
   last_updated: 2025-07-19
   sha256: 65ed14c51f61c138aa27bcf81908b491a538322b17ed1d74d1c1957a528f306c
+- path: standards/thread-routing-policy-schema-v1.json
+  type: schema
+  doc_version: 1.0.0
+  status: active
+  last_updated: 2026-07-19
+  sha256: c8363ce17943b8d5ab5cf4587c60e2b88d6f003a69be9d68d422a1785efea7f9
+- path: standards/thread-routing-decision-schema-v1.json
+  type: schema
+  doc_version: 1.0.0
+  status: active
+  last_updated: 2026-07-19
+  sha256: ec2c3b9a0d4e6bf2989b52cf8f14a41255733ec2db05dfd43891c6627342c6c5
+- path: standards/thread-summary-state-schema-v1.json
+  type: schema
+  doc_version: 1.0.0
+  status: active
+  last_updated: 2026-07-19
+  sha256: 276c9e1d39ff172a842617b375e19461f24890668ae60662848bd963c8ce2eb5
 - path: standards/admin-command-schemas/approve-interpretation.json
   type: schema
   doc_version: 1.0.0
@@ -1352,6 +1370,18 @@ artifacts:
   status: active
   last_updated: 2026-04-04
   sha256: c0a5645b08a577f59f2efc36e302757d17ad6d0a5dcf48a8cfea43d4999affb0
+- path: model-packs/business-ops/cfg/runtime-config.yaml
+  type: config
+  doc_version: 1.0.0
+  status: active
+  last_updated: 2026-07-19
+  sha256: eeb6d1aae718d30278f7d706d7499b27a47eb33d4f4b923e30804ced2afee8fc
+- path: model-packs/business-ops/cfg/thread-routing-policy.yaml
+  type: config
+  doc_version: 1.0.0
+  status: active
+  last_updated: 2026-07-19
+  sha256: 0e8b48ec4a6d86e900ab0778664a248c80345a16f7f2805d9ab442e98d957a7f
 - path: model-packs/system/cfg/ui-config.yaml
   type: config
   doc_version: 1.0.0
@@ -1988,7 +2018,7 @@ artifacts:
   doc_version: 1.0.0
   status: active
   last_updated: 2026-07-19
-  sha256: e5fa69a75ef53ff1977dcaf403338a2c8bfb431cc95fb786caceea12cc8f6cfe
+  sha256: a8b615756c6f172107129339ed97a5497fa7451f8d088ac8b93499a94490e2cc
 - path: docs/roadmap/slices/01-framework-boundary.md
   type: doc
   doc_version: 1.0.0

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -53,7 +53,7 @@ under `docs/roadmap/slices/` and delivered as a focused PR.
 | [25](slices/25-b2b-workstream-boundary-and-task-graph.md) | B2B Workstream Boundary and Global Task Graph | Planned |
 | [26](slices/26-tenant-site-actor-memory-contracts.md) | Tenant/Site/Actor Memory Contracts | Delivered |
 | [27](slices/27-institutional-vector-memory-layer.md) | Institutional Vector Memory Layer | Delivered |
-| [28](slices/28-semantic-thread-routing-and-forking.md) | Semantic Thread Routing and Context Forking | Planned |
+| [28](slices/28-semantic-thread-routing-and-forking.md) | Semantic Thread Routing and Context Forking | Delivered |
 | [29](slices/29-decision-precedent-confidence-and-escalation.md) | Decision Precedent, Confidence, and Escalation | Planned |
 | [30](slices/30-erpnext-adapter-foundation-and-fixtures.md) | Canonical Business-System Contracts and Capability Taxonomy | Planned |
 | [31](slices/31-business-ops-pack-bootstrap.md) | Connector Registry and Capability Routing | Planned |

--- a/docs/roadmap/slices/28-semantic-thread-routing-and-forking.md
+++ b/docs/roadmap/slices/28-semantic-thread-routing-and-forking.md
@@ -1,9 +1,9 @@
 ---
 title: "Slice 28 — Semantic Thread Routing and Context Forking"
 slice: 28
-status: planned
-version: 0.1.0
-last_updated: 2026-07-11
+status: delivered
+version: 1.0.0
+last_updated: 2026-07-20
 ---
 
 ## Purpose
@@ -13,6 +13,8 @@ Replace timestamp-only session creation defaults with semantic routing that can 
 ## Scope
 
 - Define thread-matching policy using scoped vector retrieval + confidence thresholds.
+- Bootstrap the Business Ops policy surface with pack-level routing defaults and
+  organization/site overrides; the System Pack enforces the resolved policy.
 - Define fork/merge rules and operator intercept prompts.
 - Define rolling recap contract for long-running thread compression into summary state.
 - Define compatibility behavior with existing transcript seals and session resume paths.
@@ -26,6 +28,9 @@ Replace timestamp-only session creation defaults with semantic routing that can 
 ## Required Changes
 
 - Add router policy documentation and data contract for thread candidates.
+- Add a policy-only `model-packs/business-ops/cfg/` foundation with a
+  versioned `thread_routing_policy`; its precedence is site override,
+  organization override, then Business Ops default.
 - Add client/server interface spec for attach/new/fork decisions.
 - Add deterministic test matrix for routing outcomes.
 
@@ -36,7 +41,10 @@ Replace timestamp-only session creation defaults with semantic routing that can 
   - `create_new`,
   - `fork_from`.
 - New `thread_summary_state` contract for recap-based continuity.
-- New confidence threshold policy contract with explicit override behavior.
+- New `thread_routing_policy` contract with configurable confidence thresholds,
+  recap cadence, candidate limits, and explicit operator-intercept behavior.
+- The System Pack owns scope enforcement, decision validation, and audit
+  evidence; Business Ops owns organization-configurable operating-policy values.
 
 ## Files Likely Touched
 
@@ -44,6 +52,8 @@ Replace timestamp-only session creation defaults with semantic routing that can 
 - `src/web/services/transcriptStore.ts`
 - `src/lumina/api/processing.py`
 - `src/lumina/api/pipeline/payload.py`
+- `model-packs/business-ops/cfg/runtime-config.yaml` (new policy-only foundation)
+- `model-packs/business-ops/cfg/thread-routing-policy.yaml` (new)
 - `tests/*thread*` (new)
 - `docs/roadmap/slices/28-semantic-thread-routing-and-forking.md`
 
@@ -52,11 +62,15 @@ Replace timestamp-only session creation defaults with semantic routing that can 
 - New user turn can be routed to existing relevant thread when confidence is high and scope matches.
 - Topic drift can produce deterministic fork behavior with explicit rationale.
 - Operator can override routing decision.
+- Organization and site configuration can tune routing thresholds without
+  bypassing System Pack scope, audit, or authority controls.
 - Raw transcript retention remains optional and not required for thread continuity.
 
 ## Tests
 
 - Deterministic routing tests with fixed embeddings/fixtures.
+- Policy-resolution tests for default, organization, and site precedence, plus
+  invalid or cross-scope configuration rejection.
 - Regression tests for existing session create/resume behavior.
 - Fork/merge policy tests across same-site and cross-site boundaries.
 
@@ -68,3 +82,5 @@ Replace timestamp-only session creation defaults with semantic routing that can 
 ## Follow-Up Slices
 
 - Slice 29: precedent confidence and escalation consumes routed thread context.
+- Slice 32: expands the policy-only Business Ops foundation into the full pack,
+  its role model, domain physics, and initial vertical workflows.

--- a/model-packs/business-ops/cfg/runtime-config.yaml
+++ b/model-packs/business-ops/cfg/runtime-config.yaml
@@ -1,0 +1,10 @@
+# version: 1.0.0
+# last_updated: 2026-07-19
+# Policy-only Business Ops foundation for Slice 28.
+#
+# This is intentionally not an activatable domain runtime configuration yet.
+# Slice 32 adds the full Business Ops pack, including adapters, profiles,
+# domain physics, modules, and role mappings.
+pack_id: business-ops
+policy_version: 1
+thread_routing_policy_path: model-packs/business-ops/cfg/thread-routing-policy.yaml

--- a/model-packs/business-ops/cfg/thread-routing-policy.yaml
+++ b/model-packs/business-ops/cfg/thread-routing-policy.yaml
@@ -1,0 +1,20 @@
+# version: 1.0.0
+# last_updated: 2026-07-19
+schema_version: 1.0.0
+policy_version: 1
+
+# Business Ops defaults. Organizations and sites may only tune these operating
+# values; System Pack scope, audit, and authority controls remain mandatory.
+defaults:
+  attach_threshold: 0.86
+  fork_threshold: 0.62
+  ambiguity_margin: 0.04
+  recap_interval_turns: 12
+  candidate_limit: 5
+  manual_only: false
+  require_operator_confirmation_for:
+    - fork_from
+    - ambiguous_attach
+
+# Configuration precedence is site, organization, then these defaults.
+organizations: {}

--- a/src/lumina/api/middleware.py
+++ b/src/lumina/api/middleware.py
@@ -13,6 +13,7 @@ from lumina.auth.auth import (
     TokenInvalidError,
     verify_scoped_jwt,
 )
+from lumina.auth.operating_context import operating_context_from_claims
 
 _bearer_scheme = HTTPBearer(auto_error=False)
 
@@ -33,6 +34,10 @@ async def get_current_user(
         raise HTTPException(status_code=401, detail="Token expired")
     except (TokenInvalidError, AuthError):
         raise HTTPException(status_code=401, detail="Invalid token")
+    try:
+        operating_context_from_claims(payload)
+    except ValueError as exc:
+        raise HTTPException(status_code=401, detail="Invalid operating context") from exc
     return payload
 
 

--- a/src/lumina/api/models.py
+++ b/src/lumina/api/models.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 # ── Chat ─────────────────────────────────────────────────────
 
 class ChatRequest(BaseModel):
     session_id: str | None = None
+    thread_id: str | None = None
     message: str
     deterministic_response: bool = False
     turn_data_override: dict[str, Any] | None = None
@@ -39,6 +40,50 @@ class ChatResponse(BaseModel):
     transcript_seal: str | None = None
     transcript_seal_metadata: dict[str, Any] | None = None
     transcript_snapshot: list[dict[str, Any]] | None = None
+
+
+# ── Thread routing ───────────────────────────────────────────
+
+class ThreadRoutingPreflightRequest(BaseModel):
+    message: str = Field(min_length=1)
+    active_thread_id: str | None = None
+    session_id: str | None = None
+
+
+class ThreadRoutingCandidateResponse(BaseModel):
+    thread_id: str
+    summary_record_id: str
+    score: float
+
+
+class ThreadRoutingPreflightResponse(BaseModel):
+    decision_id: str
+    organization_id: str
+    site_id: str
+    actor_id: str
+    decision: str
+    thread_id: str
+    source_thread_id: str | None = None
+    policy_version: int
+    confidence: float
+    rationale_code: str
+    operator_confirmation_required: bool
+    operator_override: bool = False
+    candidates: list[ThreadRoutingCandidateResponse]
+
+
+class ThreadRoutingConfirmationRequest(BaseModel):
+    action: str = "accept"
+
+
+class ThreadRoutingConfirmationResponse(BaseModel):
+    application_id: str
+    decision_id: str
+    thread_id: str
+    source_thread_id: str | None = None
+    decision: str
+    operator_override: bool
+    session_id: str
 
 
 # ── Holodeck Sandbox ─────────────────────────────────────────
@@ -130,6 +175,23 @@ class TokenResponse(BaseModel):
     token_type: str = "bearer"
     user_id: str
     role: str
+    organization_id: str | None = None
+    site_id: str | None = None
+    device_id: str | None = None
+
+
+class OperatingMembership(BaseModel):
+    """One organization and the sites an actor may operate from."""
+
+    organization_id: str
+    site_ids: list[str] = Field(min_length=1)
+    site_roles: dict[str, str] = Field(default_factory=dict)
+
+
+class OperatingContextSwitchRequest(BaseModel):
+    organization_id: str
+    site_id: str
+    device_id: str | None = None
 
 
 class UserResponse(BaseModel):
@@ -138,6 +200,7 @@ class UserResponse(BaseModel):
     role: str
     governed_modules: list[str]
     active: bool
+    operating_memberships: list[OperatingMembership] = Field(default_factory=list)
 
 
 # ── Admin ────────────────────────────────────────────────────
@@ -146,6 +209,7 @@ class UpdateUserRequest(BaseModel):
     role: str | None = None
     governed_modules: list[str] | None = None
     domain_roles: dict[str, str] | None = None  # module_id → domain_role_id
+    operating_memberships: list[OperatingMembership] | None = None
 
 
 class RevokeRequest(BaseModel):

--- a/src/lumina/api/processing.py
+++ b/src/lumina/api/processing.py
@@ -135,6 +135,9 @@ def _compute_transcript_seal(
             "turn_count": session.get("turn_count", 0),
             "last_activity_utc": time.time(),
         }
+        for _scope_key in ("organization_id", "site_id", "device_id"):
+            if user.get(_scope_key) is not None:
+                _seal_meta[_scope_key] = user[_scope_key]
         _seal = sign_transcript(
             _user_id, {"transcript": _transcript, "metadata": _seal_meta}
         )

--- a/src/lumina/api/routes/chat.py
+++ b/src/lumina/api/routes/chat.py
@@ -15,13 +15,27 @@ from lumina.api import config as _cfg
 from lumina.api.middleware import _bearer_scheme, get_current_user
 from lumina.api.models import ChatRequest, ChatResponse
 from lumina.api.processing import process_message
+from lumina.api.session import _session_containers
 from lumina.core.domain_registry import DomainNotFoundError
 from lumina.core.permissions import Operation, check_permission
 from lumina.system_log.commit_guard import requires_log_commit
+from lumina.thread_routing.bindings import load_thread_session_binding
+from lumina.thread_routing.policy import load_thread_routing_policy
+from lumina.thread_routing.summaries import record_thread_recap
+from lumina.retrieval.embedder import DocEmbedder
+from lumina.retrieval.institutional import InstitutionalMemoryIndexer
+from lumina.retrieval.vector_store import VectorStore
 
 log = logging.getLogger("lumina-api")
 
 router = APIRouter()
+
+_THREAD_ROUTING_POLICY_PATH = _cfg._REPO_ROOT / "model-packs" / "business-ops" / "cfg" / "thread-routing-policy.yaml"
+_INSTITUTIONAL_INDEX_DIR = _cfg._REPO_ROOT / "data" / "retrieval-index" / "institutional-memory"
+
+
+def _get_institutional_indexer() -> InstitutionalMemoryIndexer:
+    return InstitutionalMemoryIndexer(VectorStore(_INSTITUTIONAL_INDEX_DIR), DocEmbedder())
 
 
 def _get_accessible_domain_ids(
@@ -67,12 +81,33 @@ async def chat(
     req: ChatRequest,
     credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
 ) -> ChatResponse:
-    session_id = req.session_id or str(uuid.uuid4())
-
     if not req.message.strip():
         raise HTTPException(status_code=400, detail="Message cannot be empty")
 
     user = await get_current_user(credentials)
+    if req.thread_id is not None:
+        if user is None:
+            raise HTTPException(status_code=401, detail="Thread routing requires authentication")
+        organization_id = user.get("organization_id")
+        site_id = user.get("site_id")
+        if not isinstance(organization_id, str) or not organization_id or not isinstance(site_id, str) or not site_id:
+            raise HTTPException(status_code=403, detail="Thread routing requires an active organization and site context")
+        binding = await run_in_threadpool(
+            load_thread_session_binding,
+            _cfg.PERSISTENCE,
+            thread_id=req.thread_id,
+            organization_id=organization_id,
+            site_id=site_id,
+        )
+        if binding is None:
+            raise HTTPException(status_code=404, detail="Thread routing binding was not found")
+        if binding.actor_id != user.get("sub"):
+            raise HTTPException(status_code=403, detail="Thread routing binding belongs to another actor")
+        if req.session_id is not None and req.session_id != binding.session_id:
+            raise HTTPException(status_code=409, detail="session_id does not match the requested thread")
+        session_id = binding.session_id
+    else:
+        session_id = req.session_id or str(uuid.uuid4())
 
     # ── Domain resolution: semantic routing → explicit → default ──
     routing_record: dict[str, Any] = {
@@ -228,6 +263,31 @@ async def chat(
     except Exception as exc:
         log.exception("Error processing message for session %s", session_id)
         raise HTTPException(status_code=500, detail=str(exc))
+
+    if req.thread_id is not None and user is not None:
+        try:
+            policy = load_thread_routing_policy(
+                _THREAD_ROUTING_POLICY_PATH,
+                organization_id=str(user["organization_id"]),
+                site_id=str(user["site_id"]),
+            )
+            container = _session_containers.get(session_id)
+            turn_count = container.active_context.turn_count if container is not None else 0
+            await run_in_threadpool(
+                record_thread_recap,
+                persistence=_cfg.PERSISTENCE,
+                indexer=_get_institutional_indexer(),
+                policy=policy,
+                thread_id=req.thread_id,
+                actor_id=str(user["sub"]),
+                turn_count=turn_count,
+                message=req.message,
+                action=str(result["action"]),
+                domain_id=result.get("domain_id"),
+                device_id=user.get("device_id"),
+            )
+        except Exception:
+            log.warning("Could not record thread recap for %s", req.thread_id, exc_info=True)
 
     return ChatResponse(
         session_id=session_id,

--- a/src/lumina/api/routes/chat.py
+++ b/src/lumina/api/routes/chat.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import logging
 import time
 import uuid
@@ -34,7 +35,9 @@ _THREAD_ROUTING_POLICY_PATH = _cfg._REPO_ROOT / "model-packs" / "business-ops" /
 _INSTITUTIONAL_INDEX_DIR = _cfg._REPO_ROOT / "data" / "retrieval-index" / "institutional-memory"
 
 
+@functools.lru_cache(maxsize=1)
 def _get_institutional_indexer() -> InstitutionalMemoryIndexer:
+    """Build the recap indexer lazily and reuse it across routed chat turns."""
     return InstitutionalMemoryIndexer(VectorStore(_INSTITUTIONAL_INDEX_DIR), DocEmbedder())
 
 

--- a/src/lumina/api/routes/thread_routing.py
+++ b/src/lumina/api/routes/thread_routing.py
@@ -49,13 +49,24 @@ class _PendingDecision:
 
 
 _pending_decisions: dict[str, _PendingDecision] = {}
-_consumed_decision_ids: set[str] = set()
+_consumed_decision_ids: dict[str, float] = {}
 
 
 @functools.lru_cache(maxsize=1)
 def _get_institutional_indexer() -> InstitutionalMemoryIndexer:
     """Build the local institutional index provider lazily on first preflight."""
     return InstitutionalMemoryIndexer(VectorStore(_DEFAULT_INDEX_DIR), DocEmbedder())
+
+
+def _prune_expired_decisions(now: float | None = None) -> None:
+    """Bound in-memory routing state to the confirmation TTL."""
+    current_time = time.monotonic() if now is None else now
+    for decision_id, pending in list(_pending_decisions.items()):
+        if pending.expires_at <= current_time:
+            del _pending_decisions[decision_id]
+    for decision_id, expires_at in list(_consumed_decision_ids.items()):
+        if expires_at <= current_time:
+            del _consumed_decision_ids[decision_id]
 
 
 def _response_from_record(record: dict[str, object]) -> ThreadRoutingPreflightResponse:
@@ -172,6 +183,7 @@ async def preflight(
 
     record = preflight_result.decision.as_record()
     routing_session_id = req.session_id or "thread-routing"
+    _prune_expired_decisions()
     _pending_decisions[preflight_result.decision.decision_id] = _PendingDecision(
         decision=preflight_result.decision,
         session_id=routing_session_id,
@@ -200,15 +212,19 @@ async def confirm(
     """Confirm or override a preflight decision as auditable routing intent."""
     user = require_auth(await get_current_user(credentials))
     context = _active_context(user)
+    current_time = time.monotonic()
+    for consumed_id, expires_at in list(_consumed_decision_ids.items()):
+        if expires_at <= current_time:
+            del _consumed_decision_ids[consumed_id]
     if decision_id in _consumed_decision_ids:
         raise HTTPException(status_code=409, detail="Thread routing decision has already been applied")
     pending = _pending_decisions.get(decision_id)
     if pending is None:
         raise HTTPException(status_code=404, detail="Thread routing decision was not found")
-    if pending.expires_at <= time.monotonic():
+    if pending.expires_at <= current_time:
         del _pending_decisions[decision_id]
         raise HTTPException(status_code=410, detail="Thread routing decision has expired")
-
+    _prune_expired_decisions(current_time)
     decision = pending.decision
     if decision.actor_id != user["sub"]:
         raise HTTPException(status_code=403, detail="Thread routing decision belongs to another actor")
@@ -259,7 +275,7 @@ async def confirm(
         _cfg.PERSISTENCE.get_system_ledger_path(pending.session_id),
     )
     del _pending_decisions[decision_id]
-    _consumed_decision_ids.add(decision_id)
+    _consumed_decision_ids[decision_id] = time.monotonic() + _PENDING_DECISION_TTL_SECONDS
     return ThreadRoutingConfirmationResponse(
         application_id=application_id,
         decision_id=decision_id,

--- a/src/lumina/api/routes/thread_routing.py
+++ b/src/lumina/api/routes/thread_routing.py
@@ -1,0 +1,271 @@
+"""Authenticated, scope-safe thread-routing preflight API."""
+from __future__ import annotations
+
+import functools
+import time
+import uuid
+from dataclasses import dataclass, replace
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+from starlette.concurrency import run_in_threadpool
+
+from lumina.api import config as _cfg
+from lumina.api.middleware import _bearer_scheme, get_current_user, require_auth
+from lumina.api.models import (
+    ThreadRoutingCandidateResponse,
+    ThreadRoutingConfirmationRequest,
+    ThreadRoutingConfirmationResponse,
+    ThreadRoutingPreflightRequest,
+    ThreadRoutingPreflightResponse,
+)
+from lumina.auth.operating_context import operating_context_from_claims
+from lumina.retrieval.embedder import DocEmbedder
+from lumina.retrieval.institutional import InstitutionalMemoryIndexer
+from lumina.retrieval.vector_store import VectorStore
+from lumina.system_log.commit_guard import requires_log_commit
+from lumina.system_log.admin_operations import build_trace_event
+from lumina.thread_routing.policy import load_thread_routing_policy
+from lumina.thread_routing.router import ThreadRoutingDecision
+from lumina.thread_routing.service import preflight_thread_route
+from lumina.thread_routing.bindings import (
+    create_thread_session_binding,
+    load_thread_session_binding,
+)
+
+router = APIRouter()
+
+_POLICY_PATH = _cfg._REPO_ROOT / "model-packs" / "business-ops" / "cfg" / "thread-routing-policy.yaml"
+_DEFAULT_INDEX_DIR = _cfg._REPO_ROOT / "data" / "retrieval-index" / "institutional-memory"
+_PENDING_DECISION_TTL_SECONDS = 300
+
+
+@dataclass(frozen=True)
+class _PendingDecision:
+    decision: ThreadRoutingDecision
+    session_id: str
+    active_thread_id: str | None
+    expires_at: float
+
+
+_pending_decisions: dict[str, _PendingDecision] = {}
+_consumed_decision_ids: set[str] = set()
+
+
+@functools.lru_cache(maxsize=1)
+def _get_institutional_indexer() -> InstitutionalMemoryIndexer:
+    """Build the local institutional index provider lazily on first preflight."""
+    return InstitutionalMemoryIndexer(VectorStore(_DEFAULT_INDEX_DIR), DocEmbedder())
+
+
+def _response_from_record(record: dict[str, object]) -> ThreadRoutingPreflightResponse:
+    candidates = [
+        ThreadRoutingCandidateResponse(
+            thread_id=str(candidate["thread_id"]),
+            summary_record_id=str(candidate["summary_record_id"]),
+            score=float(candidate["score"]),
+        )
+        for candidate in record["candidates"]  # type: ignore[index]
+    ]
+    return ThreadRoutingPreflightResponse(
+        decision_id=str(record["decision_id"]),
+        organization_id=str(record["organization_id"]),
+        site_id=str(record["site_id"]),
+        actor_id=str(record["actor_id"]),
+        decision=str(record["decision"]),
+        thread_id=str(record["thread_id"]),
+        source_thread_id=record["source_thread_id"] if isinstance(record["source_thread_id"], str) else None,
+        policy_version=int(record["policy_version"]),
+        confidence=float(record["confidence"]),
+        rationale_code=str(record["rationale_code"]),
+        operator_confirmation_required=bool(record["operator_confirmation_required"]),
+        operator_override=bool(record["operator_override"]),
+        candidates=candidates,
+    )
+
+
+def _active_context(user: dict[str, object]) -> dict[str, str | None]:
+    try:
+        context = operating_context_from_claims(user)
+    except ValueError as exc:
+        raise HTTPException(status_code=403, detail="Invalid active operating context") from exc
+    if context is None:
+        raise HTTPException(status_code=403, detail="An active organization and site context is required")
+    return context
+
+
+def _resolve_confirmation(
+    pending: _PendingDecision,
+    action: str,
+) -> ThreadRoutingDecision:
+    decision = pending.decision
+    if action == "accept":
+        return decision
+    if action == "attach_existing":
+        if not decision.candidates:
+            raise HTTPException(status_code=422, detail="No scoped candidate is available to attach")
+        candidate = decision.candidates[0]
+        binding = load_thread_session_binding(
+            _cfg.PERSISTENCE,
+            thread_id=candidate.thread_id,
+            organization_id=decision.organization_id,
+            site_id=decision.site_id,
+        )
+        if binding is None:
+            raise HTTPException(status_code=409, detail="Candidate thread has no runtime session binding")
+        if binding.actor_id != decision.actor_id:
+            raise HTTPException(status_code=403, detail="Candidate thread belongs to another actor")
+        return replace(
+            decision,
+            decision="attach_existing",
+            thread_id=candidate.thread_id,
+            source_thread_id=None,
+            operator_override=True,
+        )
+    if action == "create_new":
+        return replace(
+            decision,
+            decision="create_new",
+            thread_id=f"thread-{uuid.uuid4()}",
+            source_thread_id=None,
+            operator_override=True,
+        )
+    if action == "fork_from":
+        if not pending.active_thread_id:
+            raise HTTPException(status_code=422, detail="An active thread is required to fork")
+        return replace(
+            decision,
+            decision="fork_from",
+            thread_id=f"thread-{uuid.uuid4()}",
+            source_thread_id=pending.active_thread_id,
+            operator_override=True,
+        )
+    raise HTTPException(status_code=422, detail="Unsupported routing confirmation action")
+
+
+@router.post("/api/thread-routing/preflight", response_model=ThreadRoutingPreflightResponse)
+@requires_log_commit
+async def preflight(
+    req: ThreadRoutingPreflightRequest,
+    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
+) -> ThreadRoutingPreflightResponse:
+    """Return an auditable attach/new/fork recommendation without mutating a session."""
+    user = require_auth(await get_current_user(credentials))
+    context = _active_context(user)
+
+    try:
+        policy = load_thread_routing_policy(
+            _POLICY_PATH,
+            organization_id=str(context["organization_id"]),
+            site_id=str(context["site_id"]),
+        )
+        preflight_result = await run_in_threadpool(
+            preflight_thread_route,
+            req.message,
+            indexer=_get_institutional_indexer(),
+            policy=policy,
+            actor_id=str(user["sub"]),
+            active_thread_id=req.active_thread_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    record = preflight_result.decision.as_record()
+    routing_session_id = req.session_id or "thread-routing"
+    _pending_decisions[preflight_result.decision.decision_id] = _PendingDecision(
+        decision=preflight_result.decision,
+        session_id=routing_session_id,
+        active_thread_id=req.active_thread_id,
+        expires_at=time.monotonic() + _PENDING_DECISION_TTL_SECONDS,
+    )
+    await run_in_threadpool(
+        _cfg.PERSISTENCE.append_log_record,
+        routing_session_id,
+        record,
+        _cfg.PERSISTENCE.get_system_ledger_path(routing_session_id),
+    )
+    return _response_from_record(record)
+
+
+@router.post(
+    "/api/thread-routing/{decision_id}/confirm",
+    response_model=ThreadRoutingConfirmationResponse,
+)
+@requires_log_commit
+async def confirm(
+    decision_id: str,
+    req: ThreadRoutingConfirmationRequest,
+    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
+) -> ThreadRoutingConfirmationResponse:
+    """Confirm or override a preflight decision as auditable routing intent."""
+    user = require_auth(await get_current_user(credentials))
+    context = _active_context(user)
+    if decision_id in _consumed_decision_ids:
+        raise HTTPException(status_code=409, detail="Thread routing decision has already been applied")
+    pending = _pending_decisions.get(decision_id)
+    if pending is None:
+        raise HTTPException(status_code=404, detail="Thread routing decision was not found")
+    if pending.expires_at <= time.monotonic():
+        del _pending_decisions[decision_id]
+        raise HTTPException(status_code=410, detail="Thread routing decision has expired")
+
+    decision = pending.decision
+    if decision.actor_id != user["sub"]:
+        raise HTTPException(status_code=403, detail="Thread routing decision belongs to another actor")
+    if (
+        decision.organization_id != context["organization_id"]
+        or decision.site_id != context["site_id"]
+    ):
+        raise HTTPException(status_code=403, detail="Thread routing decision is outside the active context")
+
+    selected = _resolve_confirmation(pending, req.action)
+    binding = load_thread_session_binding(
+        _cfg.PERSISTENCE,
+        thread_id=selected.thread_id,
+        organization_id=selected.organization_id,
+        site_id=selected.site_id,
+    )
+    if binding is None:
+        if selected.decision == "attach_existing":
+            raise HTTPException(status_code=409, detail="Candidate thread has no runtime session binding")
+        binding = create_thread_session_binding(
+            _cfg.PERSISTENCE,
+            thread_id=selected.thread_id,
+            session_id=str(uuid.uuid4()),
+            organization_id=selected.organization_id,
+            site_id=selected.site_id,
+            actor_id=selected.actor_id,
+        )
+    elif binding.actor_id != selected.actor_id:
+        raise HTTPException(status_code=403, detail="Thread binding belongs to another actor")
+    application_id = str(uuid.uuid4())
+    evidence = selected.as_record()
+    event = build_trace_event(
+        session_id=pending.session_id,
+        actor_id=str(user["sub"]),
+        event_type="other",
+        decision="thread_routing_confirmed",
+        evidence_summary={
+            "application_id": application_id,
+            "preflight_decision_id": decision_id,
+            "routing_decision": evidence,
+            "session_id": binding.session_id,
+        },
+    )
+    await run_in_threadpool(
+        _cfg.PERSISTENCE.append_log_record,
+        pending.session_id,
+        event,
+        _cfg.PERSISTENCE.get_system_ledger_path(pending.session_id),
+    )
+    del _pending_decisions[decision_id]
+    _consumed_decision_ids.add(decision_id)
+    return ThreadRoutingConfirmationResponse(
+        application_id=application_id,
+        decision_id=decision_id,
+        thread_id=selected.thread_id,
+        source_thread_id=selected.source_thread_id,
+        decision=selected.decision,
+        operator_override=selected.operator_override,
+        session_id=binding.session_id,
+    )

--- a/src/lumina/api/server.py
+++ b/src/lumina/api/server.py
@@ -136,6 +136,7 @@ from lumina.api.routes.admin import (  # noqa: E402
 )
 from lumina.api.routes.auth import router as auth_router  # noqa: E402
 from lumina.api.routes.chat import router as chat_router  # noqa: E402
+from lumina.api.routes.thread_routing import router as thread_routing_router  # noqa: E402
 from lumina.api.routes.system_log import router as system_log_router  # noqa: E402
 from lumina.api.routes.dashboard import router as dashboard_router  # noqa: E402
 from lumina.api.routes.domain import router as domain_router  # noqa: E402
@@ -209,6 +210,7 @@ app.add_middleware(_InFlightCounterMiddleware)
 
 # Register route groups
 app.include_router(chat_router)
+app.include_router(thread_routing_router)
 app.include_router(auth_router)
 app.include_router(system_router)
 app.include_router(domain_router)

--- a/src/lumina/auth/auth.py
+++ b/src/lumina/auth/auth.py
@@ -274,6 +274,10 @@ def create_jwt(
     governed_modules: list[str] | None = None,
     domain_roles: dict[str, str] | None = None,
     ttl_minutes: int | None = None,
+    organization_id: str | None = None,
+    site_id: str | None = None,
+    device_id: str | None = None,
+    site_role: str | None = None,
 ) -> str:
     """Create a signed JWT with Lumina claims.
 
@@ -322,6 +326,13 @@ def create_jwt(
     }
     if domain_roles:
         payload["domain_roles"] = domain_roles
+    _add_operating_context_claims(
+        payload,
+        organization_id=organization_id,
+        site_id=site_id,
+        device_id=device_id,
+        site_role=site_role,
+    )
 
     h = _b64url_encode(json.dumps(header, separators=(",", ":")).encode("utf-8"))
     p = _b64url_encode(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
@@ -414,12 +425,43 @@ def _scope_for_role(role: str) -> str:
     return "user"
 
 
+def _add_operating_context_claims(
+    payload: dict[str, Any],
+    *,
+    organization_id: str | None,
+    site_id: str | None,
+    device_id: str | None,
+    site_role: str | None,
+) -> None:
+    """Add one active organization/site context without widening JWT scope."""
+    if bool(organization_id) != bool(site_id):
+        raise ValueError("organization_id and site_id must be supplied together")
+    if not organization_id:
+        return
+    if not organization_id.strip() or not site_id or not site_id.strip():
+        raise ValueError("operating context identifiers must be non-empty")
+    payload["organization_id"] = organization_id.strip()
+    payload["site_id"] = site_id.strip()
+    if device_id:
+        if not device_id.strip():
+            raise ValueError("device_id must be non-empty when supplied")
+        payload["device_id"] = device_id.strip()
+    if site_role:
+        if not site_role.strip():
+            raise ValueError("site_role must be non-empty when supplied")
+        payload["site_role"] = site_role.strip()
+
+
 def create_scoped_jwt(
     user_id: str,
     role: str,
     governed_modules: list[str] | None = None,
     domain_roles: dict[str, str] | None = None,
     ttl_minutes: int | None = None,
+    organization_id: str | None = None,
+    site_id: str | None = None,
+    device_id: str | None = None,
+    site_role: str | None = None,
 ) -> str:
     """Create a JWT with automatic scope based on the role.
 
@@ -465,6 +507,13 @@ def create_scoped_jwt(
     }
     if domain_roles:
         payload["domain_roles"] = domain_roles
+    _add_operating_context_claims(
+        payload,
+        organization_id=organization_id,
+        site_id=site_id,
+        device_id=device_id,
+        site_role=site_role,
+    )
 
     h = _b64url_encode(json.dumps(header, separators=(",", ":")).encode("utf-8"))
     p = _b64url_encode(json.dumps(payload, separators=(",", ":")).encode("utf-8"))

--- a/src/lumina/auth/operating_context.py
+++ b/src/lumina/auth/operating_context.py
@@ -1,0 +1,115 @@
+"""Validation helpers for organization/site operating contexts."""
+from __future__ import annotations
+
+from typing import Any
+
+
+def normalize_operating_memberships(value: Any) -> list[dict[str, Any]]:
+    """Validate and normalize persisted organization/site memberships."""
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError("operating_memberships must be a list")
+
+    normalized: list[dict[str, Any]] = []
+    organization_ids: set[str] = set()
+    for membership in value:
+        if not isinstance(membership, dict):
+            raise ValueError("operating memberships must be mappings")
+        if set(membership) - {"organization_id", "site_ids", "site_roles"}:
+            raise ValueError("operating membership contains unsupported fields")
+        organization_id = membership.get("organization_id")
+        site_ids = membership.get("site_ids")
+        site_roles = membership.get("site_roles", {})
+        if not isinstance(organization_id, str) or not organization_id.strip():
+            raise ValueError("operating membership requires organization_id")
+        if organization_id in organization_ids:
+            raise ValueError("operating memberships must not repeat organization_id")
+        if not isinstance(site_ids, list) or not site_ids:
+            raise ValueError("operating membership requires site_ids")
+        clean_sites: list[str] = []
+        for site_id in site_ids:
+            if not isinstance(site_id, str) or not site_id.strip():
+                raise ValueError("operating membership site_ids must be non-empty strings")
+            if site_id.strip() in clean_sites:
+                raise ValueError("operating membership site_ids must be unique")
+            clean_sites.append(site_id.strip())
+        if not isinstance(site_roles, dict) or any(
+            site_id not in clean_sites or not isinstance(role, str) or not role.strip()
+            for site_id, role in site_roles.items()
+        ):
+            raise ValueError("site_roles must map assigned site IDs to non-empty roles")
+        organization_ids.add(organization_id.strip())
+        normalized.append(
+            {
+                "organization_id": organization_id.strip(),
+                "site_ids": clean_sites,
+                "site_roles": {site_id: role.strip() for site_id, role in site_roles.items()},
+            }
+        )
+    return normalized
+
+
+def resolve_operating_context(
+    memberships: Any,
+    *,
+    organization_id: str,
+    site_id: str,
+) -> dict[str, str | None]:
+    """Return a validated active context or reject an unassigned site."""
+    if not isinstance(organization_id, str) or not organization_id.strip():
+        raise ValueError("operating context requires organization_id")
+    if not isinstance(site_id, str) or not site_id.strip():
+        raise ValueError("operating context requires site_id")
+    organization_id = organization_id.strip()
+    site_id = site_id.strip()
+    for membership in normalize_operating_memberships(memberships):
+        if membership["organization_id"] == organization_id and site_id in membership["site_ids"]:
+            roles = membership["site_roles"]
+            return {
+                "organization_id": organization_id,
+                "site_id": site_id,
+                "site_role": roles.get(site_id),
+            }
+    raise ValueError("actor is not assigned to the requested organization and site")
+
+
+def default_operating_context(memberships: Any) -> dict[str, str | None] | None:
+    """Return the first configured context for login, or None when unassigned."""
+    normalized = normalize_operating_memberships(memberships)
+    if not normalized:
+        return None
+    membership = normalized[0]
+    return resolve_operating_context(
+        normalized,
+        organization_id=membership["organization_id"],
+        site_id=membership["site_ids"][0],
+    )
+
+
+def operating_context_from_claims(claims: dict[str, Any]) -> dict[str, str | None] | None:
+    """Extract exactly one active context from a verified JWT payload."""
+    organization_id = claims.get("organization_id")
+    site_id = claims.get("site_id")
+    if organization_id is None and site_id is None:
+        return None
+    if not isinstance(organization_id, str) or not organization_id.strip():
+        raise ValueError("JWT operating context requires organization_id")
+    if not isinstance(site_id, str) or not site_id.strip():
+        raise ValueError("JWT operating context requires site_id")
+    context: dict[str, str | None] = {
+        "organization_id": organization_id.strip(),
+        "site_id": site_id.strip(),
+        "site_role": None,
+    }
+    device_id = claims.get("device_id")
+    if device_id is not None:
+        if not isinstance(device_id, str) or not device_id.strip():
+            raise ValueError("JWT device_id must be a non-empty string")
+        context["device_id"] = device_id.strip()
+    return context
+
+
+def contexts_match(left: dict[str, Any] | None, right: dict[str, Any] | None) -> bool:
+    """Return whether two JWT-like mappings carry the same active scope."""
+    return operating_context_from_claims(left or {}) == operating_context_from_claims(right or {})

--- a/src/lumina/persistence/adapter.py
+++ b/src/lumina/persistence/adapter.py
@@ -108,6 +108,14 @@ class SystemPersistence(ABC):
         Duplicate additions are ignored (idempotent).
         """
 
+    @abstractmethod
+    def update_user_operating_memberships(
+        self,
+        user_id: str,
+        memberships: list[dict[str, Any]],
+    ) -> dict[str, Any] | None:
+        """Replace validated organization/site memberships for an existing user."""
+
     # ── User-level consent persistence ────────────────────────
 
     @abstractmethod
@@ -526,6 +534,15 @@ class NullPersistenceAdapter(PersistenceAdapter):
             if m in modules:
                 modules.remove(m)
         self._users[user_id]["governed_modules"] = modules
+        return {k: v for k, v in self._users[user_id].items() if k != "password_hash"}
+
+    def update_user_operating_memberships(
+        self, user_id: str, memberships: list[dict[str, Any]]
+    ) -> dict[str, Any] | None:
+        self.__init_users()
+        if user_id not in self._users:
+            return None
+        self._users[user_id]["operating_memberships"] = memberships
         return {k: v for k, v in self._users[user_id].items() if k != "password_hash"}
 
     def set_user_invite_token(self, user_id: str, token: str, expires_at: float) -> bool:

--- a/src/lumina/persistence/filesystem.py
+++ b/src/lumina/persistence/filesystem.py
@@ -391,6 +391,7 @@ class FilesystemPersistenceAdapter(PersistenceAdapter):
             "password_hash": password_hash,
             "role": role,
             "governed_modules": governed_modules or [],
+            "operating_memberships": [],
             "active": active,
         }
         users[user_id] = record
@@ -480,6 +481,16 @@ class FilesystemPersistenceAdapter(PersistenceAdapter):
         if remove:
             current = [m for m in current if m not in remove]
         users[user_id]["governed_modules"] = current
+        self._save_users(users)
+        return {k: v for k, v in users[user_id].items() if k != "password_hash"}
+
+    def update_user_operating_memberships(
+        self, user_id: str, memberships: list[dict[str, Any]]
+    ) -> dict[str, Any] | None:
+        users = self._load_users()
+        if user_id not in users:
+            return None
+        users[user_id]["operating_memberships"] = memberships
         self._save_users(users)
         return {k: v for k, v in users[user_id].items() if k != "password_hash"}
 

--- a/src/lumina/persistence/scoped.py
+++ b/src/lumina/persistence/scoped.py
@@ -26,6 +26,7 @@ _BLOCKED_SYSTEM_METHODS: frozenset[str] = frozenset({
     "activate_user",
     "deactivate_user",
     "update_user_password",
+    "update_user_operating_memberships",
     "set_user_invite_token",
     "clear_user_invite_token",
     "list_users",

--- a/src/lumina/persistence/sqlite.py
+++ b/src/lumina/persistence/sqlite.py
@@ -69,6 +69,7 @@ class SQLitePersistenceAdapter(PersistenceAdapter):
             role = Column(String(64), nullable=False)
             governed_modules_json = Column(Text, nullable=False, server_default="[]")
             domain_roles_json = Column(Text, nullable=False, server_default="{}")
+            operating_memberships_json = Column(Text, nullable=False, server_default="[]")
             active = Column(Boolean, nullable=False, server_default="1")
             invite_token = Column(String(128), nullable=True)
             invite_token_expires_at = Column(Text, nullable=True)
@@ -136,6 +137,7 @@ class SQLitePersistenceAdapter(PersistenceAdapter):
             for _col_ddl in (
                 "ALTER TABLE users ADD COLUMN invite_token TEXT",
                 "ALTER TABLE users ADD COLUMN invite_token_expires_at TEXT",
+                "ALTER TABLE users ADD COLUMN operating_memberships_json TEXT NOT NULL DEFAULT '[]'",
             ):
                 try:
                     await conn.execute(text(_col_ddl))
@@ -486,6 +488,7 @@ class SQLitePersistenceAdapter(PersistenceAdapter):
             "role": row.role,
             "governed_modules": json.loads(row.governed_modules_json),
             "domain_roles": json.loads(row.domain_roles_json or "{}"),
+            "operating_memberships": json.loads(row.operating_memberships_json or "[]"),
             "active": bool(row.active),
         }
 
@@ -518,6 +521,7 @@ class SQLitePersistenceAdapter(PersistenceAdapter):
             password_hash=password_hash,
             role=role,
             governed_modules_json=modules_json,
+            operating_memberships_json="[]",
             active=True,
         )
         async with self._engine.begin() as conn:
@@ -527,6 +531,7 @@ class SQLitePersistenceAdapter(PersistenceAdapter):
             "username": username,
             "role": role,
             "governed_modules": governed_modules or [],
+            "operating_memberships": [],
             "active": True,
         }
 
@@ -697,6 +702,26 @@ class SQLitePersistenceAdapter(PersistenceAdapter):
                 .where(self._User.user_id == user_id)
                 .values(governed_modules_json=json.dumps(current, ensure_ascii=False))
             )
+        return await self._get_user_async(user_id)
+
+    def update_user_operating_memberships(
+        self, user_id: str, memberships: list[dict[str, Any]]
+    ) -> dict[str, Any] | None:
+        return asyncio.run(self._update_user_operating_memberships_async(user_id, memberships))
+
+    async def _update_user_operating_memberships_async(
+        self, user_id: str, memberships: list[dict[str, Any]]
+    ) -> dict[str, Any] | None:
+        from sqlalchemy import update
+
+        async with self._engine.begin() as conn:
+            result = await conn.execute(
+                update(self._User)
+                .where(self._User.user_id == user_id)
+                .values(operating_memberships_json=json.dumps(memberships, ensure_ascii=False))
+            )
+        if result.rowcount == 0:
+            return None
         return await self._get_user_async(user_id)
 
     def set_user_invite_token(self, user_id: str, token: str, expires_at: float) -> bool:

--- a/src/lumina/retrieval/embedder.py
+++ b/src/lumina/retrieval/embedder.py
@@ -41,6 +41,7 @@ class DocChunk:
     actor_id: str | None = field(default=None, repr=False)
     device_id: str | None = field(default=None, repr=False)
     record_id: str | None = field(default=None, repr=False)
+    thread_id: str | None = field(default=None, repr=False)
     provider: str | None = field(default=None, repr=False)
     external_record_type: str | None = field(default=None, repr=False)
     external_record_id: str | None = field(default=None, repr=False)

--- a/src/lumina/retrieval/institutional.py
+++ b/src/lumina/retrieval/institutional.py
@@ -52,6 +52,11 @@ def record_to_chunk(record: dict[str, Any]) -> DocChunk:
     organization_id = _required_identifier(record, "organization_id")
     site_id = _required_identifier(record, "site_id")
     actor_id = _required_identifier(record, "actor_id")
+    thread_id = record.get("thread_id")
+    if record_type == "ThreadSummaryRecord":
+        thread_id = _required_identifier(record, "thread_id")
+    elif thread_id is not None and (not isinstance(thread_id, str) or not thread_id.strip()):
+        raise ValueError("institutional record thread_id must be a non-empty string when supplied")
     summary = _summary_text(record)
     content = json.dumps(
         {
@@ -79,6 +84,7 @@ def record_to_chunk(record: dict[str, Any]) -> DocChunk:
         actor_id=actor_id,
         device_id=record.get("device_id") if isinstance(record.get("device_id"), str) else None,
         record_id=record_id,
+        thread_id=thread_id.strip() if isinstance(thread_id, str) else None,
         provider=metadata["provider"],
         external_record_type=metadata["external_record_type"],
         external_record_id=metadata["external_record_id"],

--- a/src/lumina/retrieval/vector_store.py
+++ b/src/lumina/retrieval/vector_store.py
@@ -175,6 +175,7 @@ class VectorStore:
                 actor_id=r.get("actor_id"),
                 device_id=r.get("device_id"),
                 record_id=r.get("record_id"),
+                thread_id=r.get("thread_id"),
                 provider=r.get("provider"),
                 external_record_type=r.get("external_record_type"),
                 external_record_id=r.get("external_record_id"),

--- a/src/lumina/services/auth/routes.py
+++ b/src/lumina/services/auth/routes.py
@@ -17,6 +17,7 @@ from lumina.api.middleware import _bearer_scheme, get_current_user, require_auth
 from lumina.api.models import (
     InviteUserRequest,
     LoginRequest,
+    OperatingContextSwitchRequest,
     PasswordResetRequest,
     RegisterRequest,
     RevokeRequest,
@@ -36,6 +37,11 @@ from lumina.auth.auth import (
     revoke_token_jti,
     verify_password,
 )
+from lumina.auth.operating_context import (
+    default_operating_context,
+    normalize_operating_memberships,
+    resolve_operating_context,
+)
 from lumina.system_log.admin_operations import (
     build_domain_role_assignment,
     build_domain_role_revocation,
@@ -54,6 +60,45 @@ from lumina.core.invite_store import (
 log = logging.getLogger("lumina-api")
 
 router = APIRouter()
+
+
+def _token_response(
+    user: dict[str, Any],
+    *,
+    operating_context: dict[str, str | None] | None = None,
+    device_id: str | None = None,
+) -> TokenResponse:
+    """Issue a legacy-compatible user JWT carrying one validated context."""
+    context = operating_context or {}
+    token = create_jwt(
+        user_id=user["user_id"],
+        role=user["role"],
+        governed_modules=user.get("governed_modules") or [],
+        domain_roles=user.get("domain_roles") or {},
+        organization_id=context.get("organization_id"),
+        site_id=context.get("site_id"),
+        device_id=device_id,
+        site_role=context.get("site_role"),
+    )
+    return TokenResponse(
+        access_token=token,
+        user_id=user["user_id"],
+        role=user["role"],
+        organization_id=context.get("organization_id"),
+        site_id=context.get("site_id"),
+        device_id=device_id,
+    )
+
+
+def _user_response(user: dict[str, Any]) -> UserResponse:
+    return UserResponse(
+        user_id=user["user_id"],
+        username=user["username"],
+        role=user["role"],
+        governed_modules=user.get("governed_modules") or [],
+        active=user.get("active", True),
+        operating_memberships=user.get("operating_memberships") or [],
+    )
 
 
 @router.post("/api/auth/register", response_model=TokenResponse)
@@ -129,13 +174,7 @@ async def login(req: LoginRequest) -> TokenResponse:
             detail="Domain authorities must use /api/domain/auth/login",
         )
 
-    token = create_jwt(
-        user_id=user["user_id"],
-        role=user["role"],
-        governed_modules=user.get("governed_modules") or [],
-        domain_roles=user.get("domain_roles") or {},
-    )
-    return TokenResponse(access_token=token, user_id=user["user_id"], role=user["role"])
+    return _token_response(user, operating_context=default_operating_context(user.get("operating_memberships")))
 
 
 @router.get("/api/auth/guest-token", response_model=TokenResponse)
@@ -156,13 +195,19 @@ async def refresh(
     if user is None or not user.get("active", True):
         raise HTTPException(status_code=401, detail="User not found or deactivated")
 
-    token = create_jwt(
-        user_id=user["user_id"],
-        role=user["role"],
-        governed_modules=user.get("governed_modules") or [],
-        domain_roles=user.get("domain_roles") or {},
-    )
-    return TokenResponse(access_token=token, user_id=user["user_id"], role=user["role"])
+    try:
+        context = (
+            resolve_operating_context(
+                user.get("operating_memberships"),
+                organization_id=user_data["organization_id"],
+                site_id=user_data["site_id"],
+            )
+            if user_data.get("organization_id") or user_data.get("site_id")
+            else default_operating_context(user.get("operating_memberships"))
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=403, detail="Active operating context is no longer assigned") from exc
+    return _token_response(user, operating_context=context, device_id=user_data.get("device_id"))
 
 
 @router.get("/api/auth/me", response_model=UserResponse)
@@ -174,13 +219,7 @@ async def me(
     user = await run_in_threadpool(_cfg.PERSISTENCE.get_user, user_data["sub"])
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
-    return UserResponse(
-        user_id=user["user_id"],
-        username=user["username"],
-        role=user["role"],
-        governed_modules=user.get("governed_modules") or [],
-        active=user.get("active", True),
-    )
+    return _user_response(user)
 
 
 @router.get("/api/auth/users", response_model=list[UserResponse])
@@ -192,13 +231,7 @@ async def list_all_users(
     require_role(user_data, "root", "super_admin")
     users = await run_in_threadpool(_cfg.PERSISTENCE.list_users)
     return [
-        UserResponse(
-            user_id=u["user_id"],
-            username=u["username"],
-            role=u["role"],
-            governed_modules=u.get("governed_modules") or [],
-            active=u.get("active", True),
-        )
+        _user_response(u)
         for u in users
     ]
 
@@ -277,6 +310,36 @@ async def update_user(
             except Exception:
                 log.debug("Could not write domain_role_assignment System Log record")
 
+    if req.operating_memberships is not None:
+        try:
+            memberships = normalize_operating_memberships(
+                [membership.model_dump() for membership in req.operating_memberships]
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        membership_updated = await run_in_threadpool(
+            _cfg.PERSISTENCE.update_user_operating_memberships,
+            user_id,
+            memberships,
+        )
+        if membership_updated is not None:
+            updated = membership_updated
+        event = build_trace_event(
+            session_id="admin",
+            actor_id=user_data["sub"],
+            event_type="other",
+            decision="operating_memberships_updated",
+            evidence_summary={
+                "target_user_id": user_id,
+                "organization_count": len(memberships),
+                "site_count": sum(len(item["site_ids"]) for item in memberships),
+            },
+        )
+        _cfg.PERSISTENCE.append_log_record(
+            "admin", event,
+            ledger_path=_cfg.PERSISTENCE.get_system_ledger_path("admin"),
+        )
+
     if new_role != old_role:
         event = build_trace_event(
             session_id="admin",
@@ -297,13 +360,53 @@ async def update_user(
         except Exception:
             log.debug("Could not write role_change trace event")
 
-    return UserResponse(
-        user_id=updated["user_id"],
-        username=updated["username"],
-        role=updated["role"],
-        governed_modules=updated.get("governed_modules") or [],
-        active=updated.get("active", True),
+    return _user_response(updated)
+
+
+@router.post("/api/auth/operating-context", response_model=TokenResponse)
+@requires_log_commit
+async def switch_operating_context(
+    req: OperatingContextSwitchRequest,
+    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
+) -> TokenResponse:
+    """Validate a permitted site and replace the caller's active-context token."""
+    current = await get_current_user(credentials)
+    user_data = require_auth(current)
+    if user_data.get("token_scope") != "user":
+        raise HTTPException(status_code=403, detail="Operating context is available to user-track tokens only")
+    user = await run_in_threadpool(_cfg.PERSISTENCE.get_user, user_data["sub"])
+    if user is None or not user.get("active", True):
+        raise HTTPException(status_code=401, detail="User not found or deactivated")
+    try:
+        context = resolve_operating_context(
+            user.get("operating_memberships"),
+            organization_id=req.organization_id,
+            site_id=req.site_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+
+    old_jti = user_data.get("jti")
+    if old_jti:
+        revoke_token_jti(old_jti)
+    event = build_trace_event(
+        session_id="admin",
+        actor_id=user_data["sub"],
+        event_type="other",
+        decision="operating_context_switched",
+        evidence_summary={
+            "from_organization_id": user_data.get("organization_id"),
+            "from_site_id": user_data.get("site_id"),
+            "organization_id": context["organization_id"],
+            "site_id": context["site_id"],
+            "device_id": req.device_id,
+        },
     )
+    _cfg.PERSISTENCE.append_log_record(
+        "admin", event,
+        ledger_path=_cfg.PERSISTENCE.get_system_ledger_path("admin"),
+    )
+    return _token_response(user, operating_context=context, device_id=req.device_id)
 
 
 @router.delete("/api/auth/users/{user_id}", status_code=204)

--- a/src/lumina/services/domain/routes.py
+++ b/src/lumina/services/domain/routes.py
@@ -253,6 +253,9 @@ async def session_handoff(
         "turn_count": turn_count,
         "last_activity_utc": container.last_activity,
     }
+    for scope_key in ("organization_id", "site_id", "device_id"):
+        if user_data.get(scope_key) is not None:
+            metadata[scope_key] = user_data[scope_key]
 
     seal_payload = {"transcript": transcript, "metadata": metadata}
     seal = sign_transcript(user_id, seal_payload)
@@ -279,6 +282,14 @@ async def session_resume(
     user_data = require_auth(current)
 
     user_id: str = user_data["sub"]
+
+    from lumina.auth.operating_context import contexts_match
+
+    try:
+        if not contexts_match(req.metadata, user_data):
+            raise HTTPException(status_code=403, detail="Transcript operating context does not match active context")
+    except ValueError as exc:
+        raise HTTPException(status_code=403, detail="Transcript operating context is invalid") from exc
 
     # Verify HMAC seal
     seal_payload = {"transcript": req.transcript, "metadata": req.metadata}

--- a/src/lumina/thread_routing/__init__.py
+++ b/src/lumina/thread_routing/__init__.py
@@ -1,0 +1,13 @@
+"""Deterministic, scoped thread-routing contracts and policy resolution."""
+
+from lumina.thread_routing.policy import ThreadRoutingPolicy, load_thread_routing_policy, resolve_thread_routing_policy
+from lumina.thread_routing.router import ThreadCandidate, ThreadRoutingDecision, decide_thread_route
+
+__all__ = [
+    "ThreadCandidate",
+    "ThreadRoutingDecision",
+    "ThreadRoutingPolicy",
+    "decide_thread_route",
+    "load_thread_routing_policy",
+    "resolve_thread_routing_policy",
+]

--- a/src/lumina/thread_routing/bindings.py
+++ b/src/lumina/thread_routing/bindings.py
@@ -1,0 +1,93 @@
+"""Durable, scope-safe bindings between logical threads and runtime sessions."""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ThreadSessionBinding:
+    thread_id: str
+    session_id: str
+    organization_id: str
+    site_id: str
+    actor_id: str
+
+
+def _state_key(thread_id: str, organization_id: str, site_id: str) -> str:
+    payload = "\x1f".join((organization_id, site_id, thread_id)).encode("utf-8")
+    return f"thread-binding-{hashlib.sha256(payload).hexdigest()}"
+
+
+def _validate_identifier(value: str, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"thread binding requires {field_name}")
+    return value.strip()
+
+
+def load_thread_session_binding(
+    persistence: Any,
+    *,
+    thread_id: str,
+    organization_id: str,
+    site_id: str,
+) -> ThreadSessionBinding | None:
+    """Load a binding, rejecting malformed or scope-inconsistent persisted state."""
+    thread_id = _validate_identifier(thread_id, "thread_id")
+    organization_id = _validate_identifier(organization_id, "organization_id")
+    site_id = _validate_identifier(site_id, "site_id")
+    state = persistence.load_session_state(_state_key(thread_id, organization_id, site_id))
+    if state is None:
+        return None
+    required = ("thread_id", "session_id", "organization_id", "site_id", "actor_id")
+    if not isinstance(state, dict) or any(not isinstance(state.get(key), str) or not state[key].strip() for key in required):
+        raise ValueError("stored thread binding is invalid")
+    binding = ThreadSessionBinding(**{key: state[key].strip() for key in required})
+    if (
+        binding.thread_id != thread_id
+        or binding.organization_id != organization_id
+        or binding.site_id != site_id
+    ):
+        raise ValueError("stored thread binding scope does not match its key")
+    return binding
+
+
+def create_thread_session_binding(
+    persistence: Any,
+    *,
+    thread_id: str,
+    session_id: str,
+    organization_id: str,
+    site_id: str,
+    actor_id: str,
+) -> ThreadSessionBinding:
+    """Persist a new binding; conflicting reuse is forbidden rather than overwritten."""
+    binding = ThreadSessionBinding(
+        thread_id=_validate_identifier(thread_id, "thread_id"),
+        session_id=_validate_identifier(session_id, "session_id"),
+        organization_id=_validate_identifier(organization_id, "organization_id"),
+        site_id=_validate_identifier(site_id, "site_id"),
+        actor_id=_validate_identifier(actor_id, "actor_id"),
+    )
+    existing = load_thread_session_binding(
+        persistence,
+        thread_id=binding.thread_id,
+        organization_id=binding.organization_id,
+        site_id=binding.site_id,
+    )
+    if existing is not None:
+        if existing != binding:
+            raise ValueError("thread is already bound to a different session")
+        return existing
+    persistence.save_session_state(
+        _state_key(binding.thread_id, binding.organization_id, binding.site_id),
+        {
+            "thread_id": binding.thread_id,
+            "session_id": binding.session_id,
+            "organization_id": binding.organization_id,
+            "site_id": binding.site_id,
+            "actor_id": binding.actor_id,
+        },
+    )
+    return binding

--- a/src/lumina/thread_routing/policy.py
+++ b/src/lumina/thread_routing/policy.py
@@ -1,0 +1,173 @@
+"""Business Ops routing-policy loading and scope-safe override resolution."""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from lumina.core.yaml_loader import load_yaml
+
+_POLICY_FIELDS = frozenset({
+    "attach_threshold",
+    "fork_threshold",
+    "ambiguity_margin",
+    "recap_interval_turns",
+    "candidate_limit",
+    "manual_only",
+    "require_operator_confirmation_for",
+})
+_CONFIRMATION_ACTIONS = frozenset({
+    "attach_existing",
+    "create_new",
+    "fork_from",
+    "ambiguous_attach",
+})
+
+
+@dataclass(frozen=True)
+class ThreadRoutingPolicy:
+    """Resolved policy for one authenticated organization and site."""
+
+    policy_version: int
+    attach_threshold: float
+    fork_threshold: float
+    ambiguity_margin: float
+    recap_interval_turns: int
+    candidate_limit: int
+    manual_only: bool
+    require_operator_confirmation_for: tuple[str, ...]
+    organization_id: str
+    site_id: str
+
+
+def _require_scope(identifier: str, field_name: str) -> str:
+    if not isinstance(identifier, str) or not identifier.strip():
+        raise ValueError(f"thread routing requires {field_name}")
+    return identifier.strip()
+
+
+def _as_mapping(value: Any, field_name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"thread routing policy {field_name} must be a mapping")
+    return value
+
+
+def _merge_policy(base: dict[str, Any], override: dict[str, Any], field_name: str) -> dict[str, Any]:
+    unknown = set(override) - _POLICY_FIELDS
+    if unknown:
+        names = ", ".join(sorted(unknown))
+        raise ValueError(f"thread routing policy {field_name} has unknown fields: {names}")
+    merged = dict(base)
+    merged.update(override)
+    return merged
+
+
+def _number(value: Any, field_name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value):
+        raise ValueError(f"thread routing policy {field_name} must be a finite number")
+    numeric = float(value)
+    if not 0 <= numeric <= 1:
+        raise ValueError(f"thread routing policy {field_name} must be between 0 and 1")
+    return numeric
+
+
+def _positive_integer(value: Any, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"thread routing policy {field_name} must be a positive integer")
+    return value
+
+
+def _validate_resolved_policy(policy: dict[str, Any], *, policy_version: int, organization_id: str, site_id: str) -> ThreadRoutingPolicy:
+    missing = _POLICY_FIELDS - set(policy)
+    if missing:
+        names = ", ".join(sorted(missing))
+        raise ValueError(f"thread routing policy defaults are missing: {names}")
+    unknown = set(policy) - _POLICY_FIELDS
+    if unknown:
+        names = ", ".join(sorted(unknown))
+        raise ValueError(f"thread routing policy has unknown fields: {names}")
+    if isinstance(policy_version, bool) or not isinstance(policy_version, int) or policy_version < 1:
+        raise ValueError("thread routing policy policy_version must be a positive integer")
+
+    attach_threshold = _number(policy["attach_threshold"], "attach_threshold")
+    fork_threshold = _number(policy["fork_threshold"], "fork_threshold")
+    if fork_threshold > attach_threshold:
+        raise ValueError("thread routing policy fork_threshold cannot exceed attach_threshold")
+    confirmation_actions = policy["require_operator_confirmation_for"]
+    if not isinstance(confirmation_actions, list) or any(
+        not isinstance(action, str) or action not in _CONFIRMATION_ACTIONS
+        for action in confirmation_actions
+    ):
+        raise ValueError("thread routing policy requires valid confirmation actions")
+    if len(set(confirmation_actions)) != len(confirmation_actions):
+        raise ValueError("thread routing policy confirmation actions must be unique")
+    if not isinstance(policy["manual_only"], bool):
+        raise ValueError("thread routing policy manual_only must be boolean")
+
+    return ThreadRoutingPolicy(
+        policy_version=policy_version,
+        attach_threshold=attach_threshold,
+        fork_threshold=fork_threshold,
+        ambiguity_margin=_number(policy["ambiguity_margin"], "ambiguity_margin"),
+        recap_interval_turns=_positive_integer(policy["recap_interval_turns"], "recap_interval_turns"),
+        candidate_limit=_positive_integer(policy["candidate_limit"], "candidate_limit"),
+        manual_only=policy["manual_only"],
+        require_operator_confirmation_for=tuple(confirmation_actions),
+        organization_id=organization_id,
+        site_id=site_id,
+    )
+
+
+def resolve_thread_routing_policy(
+    config: dict[str, Any],
+    *,
+    organization_id: str,
+    site_id: str,
+) -> ThreadRoutingPolicy:
+    """Resolve site, organization, then default policy for authenticated scope."""
+    organization_id = _require_scope(organization_id, "organization_id")
+    site_id = _require_scope(site_id, "site_id")
+    unknown = set(config) - {"schema_version", "policy_version", "defaults", "organizations"}
+    if unknown:
+        names = ", ".join(sorted(unknown))
+        raise ValueError(f"thread routing policy has unknown top-level fields: {names}")
+    if config.get("schema_version") != "1.0.0":
+        raise ValueError("unsupported thread routing policy schema_version")
+    policy_version = config.get("policy_version")
+    defaults = _as_mapping(config.get("defaults"), "defaults")
+    resolved = _merge_policy({}, defaults, "defaults")
+
+    organizations = config.get("organizations", {})
+    organizations = _as_mapping(organizations, "organizations")
+    organization_override = organizations.get(organization_id, {})
+    organization_override = _as_mapping(organization_override, f"organizations.{organization_id}")
+    sites = organization_override.get("sites", {})
+    sites = _as_mapping(sites, f"organizations.{organization_id}.sites")
+    organization_fields = {key: value for key, value in organization_override.items() if key != "sites"}
+    resolved = _merge_policy(resolved, organization_fields, f"organizations.{organization_id}")
+
+    site_override = sites.get(site_id, {})
+    site_override = _as_mapping(site_override, f"organizations.{organization_id}.sites.{site_id}")
+    resolved = _merge_policy(resolved, site_override, f"organizations.{organization_id}.sites.{site_id}")
+    return _validate_resolved_policy(
+        resolved,
+        policy_version=policy_version,
+        organization_id=organization_id,
+        site_id=site_id,
+    )
+
+
+def load_thread_routing_policy(
+    config_path: str | Path,
+    *,
+    organization_id: str,
+    site_id: str,
+) -> ThreadRoutingPolicy:
+    """Load and resolve a policy file for an authenticated scope."""
+    config = load_yaml(config_path)
+    return resolve_thread_routing_policy(
+        config,
+        organization_id=organization_id,
+        site_id=site_id,
+    )

--- a/src/lumina/thread_routing/router.py
+++ b/src/lumina/thread_routing/router.py
@@ -1,0 +1,163 @@
+"""Pure, deterministic decisions over already scoped thread candidates."""
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Literal
+
+from lumina.thread_routing.policy import ThreadRoutingPolicy
+
+RoutingAction = Literal["attach_existing", "create_new", "fork_from"]
+RationaleCode = Literal[
+    "high_confidence_match",
+    "no_eligible_match",
+    "topic_drift",
+    "ambiguous_attach",
+    "manual_policy",
+    "operator_override",
+]
+
+
+@dataclass(frozen=True)
+class ThreadCandidate:
+    """One scope-filtered summary hit supplied by institutional retrieval."""
+
+    thread_id: str
+    summary_record_id: str
+    score: float
+
+    def __post_init__(self) -> None:
+        if not self.thread_id or not self.summary_record_id:
+            raise ValueError("thread candidates require thread and summary record identifiers")
+        if isinstance(self.score, bool) or not isinstance(self.score, (int, float)):
+            raise ValueError("thread candidate score must be numeric")
+        if not 0 <= self.score <= 1:
+            raise ValueError("thread candidate score must be between 0 and 1")
+
+
+@dataclass(frozen=True)
+class ThreadRoutingDecision:
+    """Transcript-free, auditable choice for routing one incoming turn."""
+
+    decision_id: str
+    organization_id: str
+    site_id: str
+    actor_id: str
+    decision: RoutingAction
+    thread_id: str
+    source_thread_id: str | None
+    policy_version: int
+    confidence: float
+    rationale_code: RationaleCode
+    operator_confirmation_required: bool
+    candidates: tuple[ThreadCandidate, ...]
+    operator_override: bool = False
+
+    def as_record(self, *, created_utc: datetime | None = None) -> dict[str, object]:
+        """Serialize the decision as a schema-valid, transcript-free record."""
+        timestamp = created_utc or datetime.now(UTC)
+        return {
+            "schema_version": "1.0.0",
+            "decision_id": self.decision_id,
+            "organization_id": self.organization_id,
+            "site_id": self.site_id,
+            "actor_id": self.actor_id,
+            "decision": self.decision,
+            "thread_id": self.thread_id,
+            "source_thread_id": self.source_thread_id,
+            "policy_version": self.policy_version,
+            "confidence": self.confidence,
+            "rationale_code": self.rationale_code,
+            "operator_confirmation_required": self.operator_confirmation_required,
+            "operator_override": self.operator_override,
+            "candidates": [
+                {
+                    "thread_id": candidate.thread_id,
+                    "summary_record_id": candidate.summary_record_id,
+                    "score": candidate.score,
+                    "rank": rank,
+                }
+                for rank, candidate in enumerate(self.candidates, start=1)
+            ],
+            "created_utc": timestamp.isoformat().replace("+00:00", "Z"),
+        }
+
+
+def _new_thread_id() -> str:
+    return f"thread-{uuid.uuid4()}"
+
+
+def _ordered_candidates(candidates: list[ThreadCandidate], limit: int) -> tuple[ThreadCandidate, ...]:
+    return tuple(sorted(candidates, key=lambda candidate: (-candidate.score, candidate.thread_id))[:limit])
+
+
+def decide_thread_route(
+    candidates: list[ThreadCandidate],
+    policy: ThreadRoutingPolicy,
+    *,
+    actor_id: str,
+    active_thread_id: str | None = None,
+    decision_id: str | None = None,
+    new_thread_id: str | None = None,
+) -> ThreadRoutingDecision:
+    """Choose attach, create, or fork without inspecting raw transcript text."""
+    if not actor_id or not actor_id.strip():
+        raise ValueError("thread routing requires actor_id")
+    ordered = _ordered_candidates(candidates, policy.candidate_limit)
+    best = ordered[0] if ordered else None
+    active = next((candidate for candidate in ordered if candidate.thread_id == active_thread_id), None)
+    generated_thread_id = new_thread_id or _new_thread_id()
+
+    decision: RoutingAction
+    thread_id: str
+    source_thread_id: str | None = None
+    confidence = best.score if best else 0.0
+    rationale: RationaleCode
+
+    if policy.manual_only:
+        decision = "create_new"
+        thread_id = generated_thread_id
+        rationale = "manual_policy"
+    elif best is not None and best.score >= policy.attach_threshold:
+        decision = "attach_existing"
+        thread_id = best.thread_id
+        rationale = "high_confidence_match"
+    elif active_thread_id and (active is None or active.score < policy.fork_threshold):
+        decision = "fork_from"
+        thread_id = generated_thread_id
+        source_thread_id = active_thread_id
+        confidence = active.score if active else 0.0
+        rationale = "topic_drift"
+    else:
+        decision = "create_new"
+        thread_id = generated_thread_id
+        rationale = "no_eligible_match"
+
+    ambiguous = (
+        decision == "attach_existing"
+        and len(ordered) > 1
+        and best is not None
+        and best.score - ordered[1].score <= policy.ambiguity_margin
+    )
+    if ambiguous:
+        rationale = "ambiguous_attach"
+    confirmation_required = (
+        policy.manual_only
+        or ambiguous
+        or decision in policy.require_operator_confirmation_for
+    )
+    return ThreadRoutingDecision(
+        decision_id=decision_id or str(uuid.uuid4()),
+        organization_id=policy.organization_id,
+        site_id=policy.site_id,
+        actor_id=actor_id.strip(),
+        decision=decision,
+        thread_id=thread_id,
+        source_thread_id=source_thread_id,
+        policy_version=policy.policy_version,
+        confidence=confidence,
+        rationale_code=rationale,
+        operator_confirmation_required=confirmation_required,
+        candidates=ordered,
+    )

--- a/src/lumina/thread_routing/service.py
+++ b/src/lumina/thread_routing/service.py
@@ -1,0 +1,81 @@
+"""Scope-safe institutional retrieval bridge for thread-routing preflight."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from lumina.retrieval.contracts import RetrievalFilter
+from lumina.retrieval.institutional import InstitutionalMemoryIndexer
+from lumina.thread_routing.policy import ThreadRoutingPolicy
+from lumina.thread_routing.router import (
+    ThreadCandidate,
+    ThreadRoutingDecision,
+    decide_thread_route,
+)
+
+
+@dataclass(frozen=True)
+class ThreadRoutingPreflight:
+    """Decision plus the scoped retrieval hits used to make it."""
+
+    decision: ThreadRoutingDecision
+    candidates: tuple[ThreadCandidate, ...]
+
+
+def _confidence_from_cosine(score: float) -> float:
+    """Map cosine similarity from $[-1, 1]$ to routing confidence $[0, 1]$."""
+    return max(0.0, min(1.0, (score + 1.0) / 2.0))
+
+
+def _thread_candidates(results: object) -> list[ThreadCandidate]:
+    """Collapse multiple summary hits to each thread's strongest candidate."""
+    strongest: dict[str, ThreadCandidate] = {}
+    for result in results:
+        chunk = result.chunk
+        if not chunk.thread_id or not chunk.record_id:
+            continue
+        candidate = ThreadCandidate(
+            thread_id=chunk.thread_id,
+            summary_record_id=chunk.record_id,
+            score=_confidence_from_cosine(result.score),
+        )
+        current = strongest.get(candidate.thread_id)
+        if current is None or (candidate.score, candidate.summary_record_id) > (
+            current.score,
+            current.summary_record_id,
+        ):
+            strongest[candidate.thread_id] = candidate
+    return list(strongest.values())
+
+
+def preflight_thread_route(
+    query: str,
+    *,
+    indexer: InstitutionalMemoryIndexer,
+    policy: ThreadRoutingPolicy,
+    actor_id: str,
+    active_thread_id: str | None = None,
+) -> ThreadRoutingPreflight:
+    """Retrieve same-site summaries and select an auditable thread route.
+
+    Incoming text is used only to compute an in-memory query embedding; returned
+    evidence contains summary record IDs and scores, never the query text.
+    """
+    if not isinstance(query, str) or not query.strip():
+        raise ValueError("thread routing preflight requires a non-empty query")
+    results = indexer.search(
+        query,
+        RetrievalFilter(
+            organization_id=policy.organization_id,
+            site_id=policy.site_id,
+            institutional_only=True,
+        ),
+        k=policy.candidate_limit,
+    )
+    candidates = _thread_candidates(results)
+    decision = decide_thread_route(
+        candidates,
+        policy,
+        actor_id=actor_id,
+        active_thread_id=active_thread_id,
+    )
+    return ThreadRoutingPreflight(decision=decision, candidates=decision.candidates)

--- a/src/lumina/thread_routing/summaries.py
+++ b/src/lumina/thread_routing/summaries.py
@@ -1,0 +1,101 @@
+"""Transcript-free rolling recap state for scoped routed threads."""
+from __future__ import annotations
+
+import hashlib
+import re
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from lumina.retrieval.institutional import InstitutionalMemoryIndexer
+from lumina.thread_routing.policy import ThreadRoutingPolicy
+
+_TOKEN_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]{2,}")
+_STOP_WORDS = frozenset({
+    "about", "after", "again", "because", "before", "could", "from", "have",
+    "here", "into", "just", "need", "please", "that", "the", "this", "what",
+    "when", "with", "would", "your",
+})
+
+
+def _state_key(thread_id: str, organization_id: str, site_id: str) -> str:
+    payload = "\x1f".join((organization_id, site_id, thread_id)).encode("utf-8")
+    return f"thread-summary-{hashlib.sha256(payload).hexdigest()}"
+
+
+def _topics(message: str) -> list[str]:
+    """Derive bounded topic labels, never retaining the source turn verbatim."""
+    labels: list[str] = []
+    for token in _TOKEN_RE.findall(message.lower()):
+        if token not in _STOP_WORDS and token not in labels:
+            labels.append(token)
+        if len(labels) == 6:
+            break
+    return labels or ["general"]
+
+
+def record_thread_recap(
+    *,
+    persistence: Any,
+    indexer: InstitutionalMemoryIndexer,
+    policy: ThreadRoutingPolicy,
+    thread_id: str,
+    actor_id: str,
+    turn_count: int,
+    message: str,
+    action: str,
+    domain_id: str | None,
+    device_id: str | None = None,
+) -> dict[str, Any] | None:
+    """Persist and index a recap at turn one and each configured recap interval."""
+    if turn_count < 1:
+        raise ValueError("thread recap requires a positive turn count")
+    state = persistence.load_session_state(_state_key(thread_id, policy.organization_id, policy.site_id))
+    previous = state.get("summary_state") if isinstance(state, dict) else None
+    if previous is not None and not isinstance(previous, dict):
+        raise ValueError("stored thread summary state is invalid")
+    previous_end = int(previous.get("turn_end", 0)) if previous else 0
+    if previous and turn_count < previous_end:
+        raise ValueError("thread recap turn count cannot move backwards")
+    if previous and turn_count - previous_end < policy.recap_interval_turns:
+        return None
+
+    labels = _topics(message)
+    recap_version = int(previous.get("recap_version", 0)) + 1 if previous else 1
+    summary_record_id = str(uuid.uuid4())
+    updated_utc = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    summary_state: dict[str, Any] = {
+        "schema_version": "1.0.0",
+        "thread_id": thread_id,
+        "organization_id": policy.organization_id,
+        "site_id": policy.site_id,
+        "actor_id": actor_id,
+        "status": "open",
+        "summary_record_id": summary_record_id,
+        "recap_version": recap_version,
+        "turn_start": previous_end + 1,
+        "turn_end": turn_count,
+        "topics": labels,
+        "updated_utc": updated_utc,
+    }
+    if device_id:
+        summary_state["device_id"] = device_id
+    summary = "Topics: " + ", ".join(labels) + f". Latest action: {action}."
+    record: dict[str, Any] = {
+        "record_type": "ThreadSummaryRecord",
+        "record_id": summary_record_id,
+        "organization_id": policy.organization_id,
+        "site_id": policy.site_id,
+        "actor_id": actor_id,
+        "thread_id": thread_id,
+        "summary": summary,
+        "domain_id": domain_id or "",
+    }
+    if device_id:
+        record["device_id"] = device_id
+    indexer.ingest([record])
+    persistence.save_session_state(
+        _state_key(thread_id, policy.organization_id, policy.site_id),
+        {"summary_state": summary_state},
+    )
+    return summary_state

--- a/src/web/app.tsx
+++ b/src/web/app.tsx
@@ -212,7 +212,11 @@ async function orchestratorApiCall(
 
 function jwtHasOperatingContext(token: string): boolean {
   try {
-    const payload = JSON.parse(atob(token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')))
+    const encodedPayload = token.split('.')[1]
+    if (!encodedPayload) return false
+    const base64Payload = encodedPayload.replace(/-/g, '+').replace(/_/g, '/')
+    const paddedPayload = base64Payload.padEnd(base64Payload.length + ((4 - base64Payload.length % 4) % 4), '=')
+    const payload = JSON.parse(atob(paddedPayload))
     return typeof payload.organization_id === 'string' && typeof payload.site_id === 'string'
   } catch {
     return false
@@ -1061,6 +1065,7 @@ function ChatInterface({
         )
         if (preflight.operator_confirmation_required) {
           setPendingRouting({ message: trimmedInput, decision: preflight })
+          setIsLoading(false)
           return
         }
         const confirmation = await threadRoutingCall<ThreadRoutingConfirmation>(

--- a/src/web/app.tsx
+++ b/src/web/app.tsx
@@ -50,6 +50,20 @@ type ApiChatResponse = {
   transcript_snapshot?: TranscriptTurn[]
 }
 
+type ThreadRoutingPreflight = {
+  decision_id: string
+  decision: 'attach_existing' | 'create_new' | 'fork_from'
+  thread_id: string
+  operator_confirmation_required: boolean
+  candidates: Array<{ thread_id: string }>
+}
+
+type ThreadRoutingConfirmation = {
+  thread_id: string
+  session_id: string
+  decision: 'attach_existing' | 'create_new' | 'fork_from'
+}
+
 interface UiManifest {
   title: string
   subtitle: string
@@ -169,6 +183,7 @@ async function loadDomainPlugin(domainKey: string): Promise<void> {
 async function orchestratorApiCall(
   userText: string,
   sessionId: string | null,
+  threadId: string | null,
   auth: AuthState | null,
 ): Promise<ApiChatResponse> {
   const headers: Record<string, string> = {
@@ -182,6 +197,7 @@ async function orchestratorApiCall(
     headers,
     body: JSON.stringify({
       session_id: sessionId,
+      thread_id: threadId,
       message: userText,
     }),
   })
@@ -192,6 +208,31 @@ async function orchestratorApiCall(
   }
 
   return (await res.json()) as ApiChatResponse
+}
+
+function jwtHasOperatingContext(token: string): boolean {
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')))
+    return typeof payload.organization_id === 'string' && typeof payload.site_id === 'string'
+  } catch {
+    return false
+  }
+}
+
+async function threadRoutingCall<T>(
+  path: string,
+  body: Record<string, unknown>,
+  auth: AuthState,
+): Promise<T> {
+  const res = await fetch(`${getApiBase()}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${auth.token}` },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    throw new Error(`${res.status}:${await res.text()}`)
+  }
+  return (await res.json()) as T
 }
 
 type AdminCommandResponse = {
@@ -704,6 +745,10 @@ function ChatInterface({
   const [sessionId, setSessionId] = useState<string | null>(null)
   const [sessionPanelOpen, setSessionPanelOpen] = useState(true)
   const [sessionRefreshKey, setSessionRefreshKey] = useState(0)
+  const [pendingRouting, setPendingRouting] = useState<{
+    message: string
+    decision: ThreadRoutingPreflight
+  } | null>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
 
   // ── Client-side transcript persistence ───────────────────
@@ -714,6 +759,7 @@ function ChatInterface({
   const turnCounterRef = useRef<number>(0)
   const sessionLabelRef = useRef<string>('')
   const activeModuleIdRef = useRef<string>('')
+  const threadIdRef = useRef<string | null>(null)
 
   // ── Session management helpers ───────────────────────────
   const resetChatState = () => {
@@ -726,6 +772,8 @@ function ChatInterface({
     turnCounterRef.current = 0
     sessionLabelRef.current = ''
     activeModuleIdRef.current = ''
+    threadIdRef.current = null
+    setPendingRouting(null)
   }
 
   const saveCurrentSession = async () => {
@@ -733,6 +781,7 @@ function ChatInterface({
     if (sessionId && sealRef.current && transcriptRef.current.length > 0 && meta) {
       await transcriptStoreRef.current.saveSession({
         sessionId,
+        threadId: threadIdRef.current ?? undefined,
         messages: transcriptRef.current,
         seal: sealRef.current,
         metadata: meta,
@@ -849,6 +898,7 @@ function ChatInterface({
           turnCounterRef.current = stored.messages.length
           sessionLabelRef.current = stored.label ?? ''
           activeModuleIdRef.current = stored.moduleId ?? ''
+          threadIdRef.current = stored.threadId ?? null
         } else {
           // Server rejected the seal — wipe stale local data
           await store.deleteSession(sessionId)
@@ -877,6 +927,7 @@ function ChatInterface({
       if (sessionId && sealRef.current && transcriptRef.current.length > 0 && meta) {
         transcriptStoreRef.current.saveSession({
           sessionId,
+          threadId: threadIdRef.current ?? undefined,
           messages: transcriptRef.current,
           seal: sealRef.current,
           metadata: meta,
@@ -1000,7 +1051,29 @@ function ChatInterface({
       }
 
       // ── Normal chat flow ────────────────────────────────
-      const apiResponse = await orchestratorApiCall(trimmedInput, sessionId, auth)
+      let activeThreadId = threadIdRef.current
+      let activeSessionId = sessionId
+      if (!activeThreadId && jwtHasOperatingContext(auth.token)) {
+        const preflight = await threadRoutingCall<ThreadRoutingPreflight>(
+          '/api/thread-routing/preflight',
+          { message: trimmedInput, session_id: sessionId },
+          auth,
+        )
+        if (preflight.operator_confirmation_required) {
+          setPendingRouting({ message: trimmedInput, decision: preflight })
+          return
+        }
+        const confirmation = await threadRoutingCall<ThreadRoutingConfirmation>(
+          `/api/thread-routing/${preflight.decision_id}/confirm`,
+          { action: 'accept' },
+          auth,
+        )
+        activeThreadId = confirmation.thread_id
+        activeSessionId = confirmation.session_id
+        threadIdRef.current = activeThreadId
+        setSessionId(activeSessionId)
+      }
+      const apiResponse = await orchestratorApiCall(trimmedInput, activeSessionId, activeThreadId, auth)
 
       const assistantMessage: Message = {
         role: 'assistant',
@@ -1049,9 +1122,10 @@ function ChatInterface({
           }
           transcriptRef.current = [...transcriptRef.current, turn]
         }
-        if (sessionId) {
+        if (activeSessionId) {
           transcriptStoreRef.current.saveSession({
-            sessionId,
+            sessionId: activeSessionId,
+            threadId: activeThreadId ?? undefined,
             messages: transcriptRef.current,
             seal: sealRef.current,
             metadata: apiResponse.transcript_seal_metadata!,
@@ -1072,6 +1146,63 @@ function ChatInterface({
         id: `error-${Date.now()}`,
       }
       setMessages((prev) => [...prev, errorMessage])
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const confirmPendingRouting = async (action: 'accept' | 'attach_existing' | 'create_new' | 'fork_from') => {
+    if (!pendingRouting || isLoading) return
+    setIsLoading(true)
+    try {
+      const confirmation = await threadRoutingCall<ThreadRoutingConfirmation>(
+        `/api/thread-routing/${pendingRouting.decision.decision_id}/confirm`,
+        { action },
+        auth,
+      )
+      threadIdRef.current = confirmation.thread_id
+      setSessionId(confirmation.session_id)
+      setPendingRouting(null)
+      const apiResponse = await orchestratorApiCall(
+        pendingRouting.message,
+        confirmation.session_id,
+        confirmation.thread_id,
+        auth,
+      )
+      setMessages((prev) => [...prev, {
+        role: 'assistant', content: apiResponse.response, id: `assistant-${Date.now()}`,
+        meta: { action: apiResponse.action, promptType: apiResponse.prompt_type, escalated: apiResponse.escalated },
+        structured_content: apiResponse.structured_content as ActionCardData | undefined,
+      }])
+      if (apiResponse.transcript_seal && apiResponse.transcript_seal_metadata) {
+        sealRef.current = apiResponse.transcript_seal
+        sealMetadataRef.current = apiResponse.transcript_seal_metadata
+        turnCounterRef.current += 1
+        transcriptRef.current = Array.isArray(apiResponse.transcript_snapshot)
+          ? apiResponse.transcript_snapshot as TranscriptTurn[]
+          : [...transcriptRef.current, {
+              turn: turnCounterRef.current,
+              user: pendingRouting.message,
+              assistant: apiResponse.response,
+              ts: Date.now() / 1000,
+              domain_id: apiResponse.transcript_seal_metadata.domain_id,
+            }]
+        await transcriptStoreRef.current.saveSession({
+          sessionId: confirmation.session_id,
+          threadId: confirmation.thread_id,
+          messages: transcriptRef.current,
+          seal: sealRef.current,
+          metadata: apiResponse.transcript_seal_metadata,
+          updatedAt: Date.now(),
+          label: sessionLabelRef.current || undefined,
+          moduleId: activeModuleIdRef.current || undefined,
+        })
+        setSessionRefreshKey((value) => value + 1)
+      }
+    } catch {
+      setMessages((prev) => [...prev, {
+        role: 'assistant', content: 'Routing confirmation could not be applied.', id: `error-${Date.now()}`,
+      }])
     } finally {
       setIsLoading(false)
     }
@@ -1178,6 +1309,16 @@ function ChatInterface({
           </ScrollArea>
 
           <div className="border-t border-border bg-card px-6 py-4">
+            {pendingRouting && (
+              <div className="max-w-3xl mx-auto mb-3 flex items-center gap-2 border border-border bg-muted px-3 py-2 text-sm">
+                <span className="flex-1">Choose where to continue this conversation.</span>
+                {pendingRouting.decision.candidates.length > 0 && (
+                  <Button variant="outline" size="sm" onClick={() => confirmPendingRouting('attach_existing')}>Attach</Button>
+                )}
+                <Button variant="outline" size="sm" onClick={() => confirmPendingRouting('create_new')}>New</Button>
+                <Button variant="outline" size="sm" onClick={() => confirmPendingRouting('fork_from')}>Fork</Button>
+              </div>
+            )}
             {sessionFrozen && (
               <div className="max-w-3xl mx-auto mb-3 rounded-lg bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-300 dark:border-yellow-700 px-4 py-2 text-sm text-yellow-800 dark:text-yellow-200 flex items-center gap-2">
                 <Warning size={16} weight="bold" />
@@ -1207,14 +1348,14 @@ function ChatInterface({
                 }}
                 onKeyDown={handleKeyPress}
                 placeholder={sessionFrozen ? '6-digit PIN' : (manifest.input_placeholder ?? manifest.placeholder_text)}
-                disabled={isLoading}
+                disabled={isLoading || pendingRouting !== null}
                 className="flex-1 text-base"
                 inputMode={sessionFrozen ? 'numeric' : undefined}
                 pattern={sessionFrozen ? '\\d{6}' : undefined}
               />
               <Button
                 onClick={handleSend}
-                disabled={!inputValue.trim() || isLoading}
+                disabled={!inputValue.trim() || isLoading || pendingRouting !== null}
                 size="icon"
                 className="bg-primary hover:bg-primary/90 text-primary-foreground h-10 w-10"
               >

--- a/src/web/services/transcriptStore.ts
+++ b/src/web/services/transcriptStore.ts
@@ -24,6 +24,7 @@ export interface TranscriptMetadata {
 
 export interface StoredSession {
   sessionId: string
+  threadId?: string
   messages: TranscriptTurn[]
   seal: string
   metadata: TranscriptMetadata
@@ -34,6 +35,7 @@ export interface StoredSession {
 
 export interface SessionSummary {
   sessionId: string
+  threadId?: string
   turnCount: number
   updatedAt: number
   domainId: string
@@ -111,6 +113,7 @@ export class IndexedDBTranscriptStore implements TranscriptStore {
         resolve(
           sessions.map((s) => ({
             sessionId: s.sessionId,
+            threadId: s.threadId,
             turnCount: s.messages.length,
             updatedAt: s.updatedAt,
             domainId: s.metadata.domain_id,
@@ -160,6 +163,7 @@ export class LocalStorageTranscriptStore implements TranscriptStore {
         const s = JSON.parse(localStorage.getItem(key)!) as StoredSession
         summaries.push({
           sessionId: s.sessionId,
+          threadId: s.threadId,
           turnCount: s.messages.length,
           updatedAt: s.updatedAt,
           domainId: s.metadata.domain_id,

--- a/src/web/src/app.test.tsx
+++ b/src/web/src/app.test.tsx
@@ -99,7 +99,7 @@ describe('App', () => {
   it('routes a scoped first turn before sending chat', async () => {
     const scopedAuth = {
       ...AUTH_STATE,
-      token: `header.${btoa(JSON.stringify({ organization_id: 'org-a', site_id: 'site-a' }))}.signature`,
+      token: `header.${btoa(JSON.stringify({ organization_id: 'org-a', site_id: 'site-a', padding: 'x' })).replace(/=+$/, '').replace(/\+/g, '-').replace(/\//g, '_')}.signature`,
     }
     window.localStorage.setItem('lumina.auth', JSON.stringify(scopedAuth))
     const fetchMock = vi.fn().mockImplementation((url: string, options?: RequestInit) => {
@@ -140,6 +140,50 @@ describe('App', () => {
       expect(JSON.parse(String(chatCall?.[1]?.body))).toMatchObject({
         session_id: 'session-1', thread_id: 'thread-1', message: 'inventory review',
       })
+    })
+  })
+
+  it('allows confirmation after a routing intercept', async () => {
+    const scopedAuth = {
+      ...AUTH_STATE,
+      token: `header.${btoa(JSON.stringify({ organization_id: 'org-a', site_id: 'site-a' }))}.signature`,
+    }
+    window.localStorage.setItem('lumina.auth', JSON.stringify(scopedAuth))
+    const fetchMock = vi.fn().mockImplementation((url: string, options?: RequestInit) => {
+      if (url.includes('/api/auth/me') || url.includes('/api/consent/accept')) return Promise.resolve({ ok: true })
+      if (url.includes('/api/domain-info')) return Promise.resolve({ ok: true, json: async () => DOMAIN_INFO_RESPONSE })
+      if (url.includes('/api/thread-routing/preflight')) {
+        return Promise.resolve({ ok: true, json: async () => ({
+          decision_id: 'decision-2', decision: 'create_new', thread_id: 'thread-2',
+          operator_confirmation_required: true, candidates: [],
+        }) })
+      }
+      if (url.includes('/api/thread-routing/decision-2/confirm')) {
+        expect(JSON.parse(String(options?.body))).toEqual({ action: 'create_new' })
+        return Promise.resolve({ ok: true, json: async () => ({
+          thread_id: 'thread-2', session_id: 'session-2', decision: 'create_new',
+        }) })
+      }
+      if (url.includes('/api/chat')) return Promise.resolve({ ok: true, json: async () => ({
+        session_id: 'session-2', response: 'Confirmed response', action: 'continue', prompt_type: 'standard', escalated: false,
+      }) })
+      return Promise.resolve({ ok: false, text: async () => 'unmocked route' })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<App />)
+    await screen.findByRole('button', { name: 'I Agree' })
+    fireEvent.click(screen.getByRole('button', { name: 'I Agree' }))
+    const input = await screen.findByRole('textbox')
+    fireEvent.change(input, { target: { value: 'new work order' } })
+    fireEvent.click(screen.getByRole('button', { name: '' }))
+
+    const newButton = await screen.findByRole('button', { name: 'New' })
+    expect(newButton).toBeEnabled()
+    fireEvent.click(newButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('Confirmed response')).toBeInTheDocument()
     })
   })
 })

--- a/src/web/src/app.test.tsx
+++ b/src/web/src/app.test.tsx
@@ -95,4 +95,51 @@ describe('App', () => {
       ).toBeInTheDocument()
     })
   })
+
+  it('routes a scoped first turn before sending chat', async () => {
+    const scopedAuth = {
+      ...AUTH_STATE,
+      token: `header.${btoa(JSON.stringify({ organization_id: 'org-a', site_id: 'site-a' }))}.signature`,
+    }
+    window.localStorage.setItem('lumina.auth', JSON.stringify(scopedAuth))
+    const fetchMock = vi.fn().mockImplementation((url: string, options?: RequestInit) => {
+      if (url.includes('/api/auth/me') || url.includes('/api/consent/accept')) return Promise.resolve({ ok: true })
+      if (url.includes('/api/domain-info')) return Promise.resolve({ ok: true, json: async () => DOMAIN_INFO_RESPONSE })
+      if (url.includes('/api/thread-routing/preflight')) {
+        return Promise.resolve({ ok: true, json: async () => ({
+          decision_id: 'decision-1', decision: 'create_new', thread_id: 'thread-1',
+          operator_confirmation_required: false, candidates: [],
+        }) })
+      }
+      if (url.includes('/api/thread-routing/decision-1/confirm')) {
+        return Promise.resolve({ ok: true, json: async () => ({
+          thread_id: 'thread-1', session_id: 'session-1', decision: 'create_new',
+        }) })
+      }
+      if (url.includes('/api/chat')) {
+        const payload = JSON.parse(String(options?.body))
+        return Promise.resolve({ ok: true, json: async () => ({
+          session_id: payload.session_id, response: 'Routed response', action: 'continue',
+          prompt_type: 'standard', escalated: false,
+        }) })
+      }
+      return Promise.resolve({ ok: false, text: async () => 'unmocked route' })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<App />)
+    await screen.findByRole('button', { name: 'I Agree' })
+    fireEvent.click(screen.getByRole('button', { name: 'I Agree' }))
+    const input = await screen.findByRole('textbox')
+    fireEvent.change(input, { target: { value: 'inventory review' } })
+    fireEvent.click(screen.getByRole('button', { name: '' }))
+
+    await waitFor(() => {
+      const chatCall = fetchMock.mock.calls.find(([url]) => String(url).includes('/api/chat'))
+      expect(chatCall).toBeDefined()
+      expect(JSON.parse(String(chatCall?.[1]?.body))).toMatchObject({
+        session_id: 'session-1', thread_id: 'thread-1', message: 'inventory review',
+      })
+    })
+  })
 })

--- a/standards/thread-routing-decision-schema-v1.json
+++ b/standards/thread-routing-decision-schema-v1.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://projectlumina.org/thread-routing-decision-schema-v1.json",
+  "schema_version": "1.0.0",
+  "last_updated": "2026-07-19",
+  "title": "Thread Routing Decision Schema V1",
+  "description": "Auditable, transcript-free routing evidence for one scoped user turn.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "decision_id",
+    "organization_id",
+    "site_id",
+    "actor_id",
+    "decision",
+    "thread_id",
+    "policy_version",
+    "confidence",
+    "rationale_code",
+    "operator_confirmation_required",
+    "operator_override",
+    "candidates",
+    "created_utc"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0.0" },
+    "decision_id": { "type": "string", "minLength": 1 },
+    "organization_id": { "type": "string", "minLength": 1 },
+    "site_id": { "type": "string", "minLength": 1 },
+    "actor_id": { "type": "string", "minLength": 1 },
+    "device_id": { "type": ["string", "null"], "minLength": 1 },
+    "decision": { "type": "string", "enum": ["attach_existing", "create_new", "fork_from"] },
+    "thread_id": { "type": "string", "minLength": 1 },
+    "source_thread_id": { "type": ["string", "null"], "minLength": 1 },
+    "policy_version": { "type": "integer", "minimum": 1 },
+    "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+    "rationale_code": {
+      "type": "string",
+      "enum": ["high_confidence_match", "no_eligible_match", "topic_drift", "ambiguous_attach", "manual_policy", "operator_override"]
+    },
+    "operator_confirmation_required": { "type": "boolean" },
+    "operator_override": { "type": "boolean" },
+    "candidates": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["thread_id", "summary_record_id", "score", "rank"],
+        "properties": {
+          "thread_id": { "type": "string", "minLength": 1 },
+          "summary_record_id": { "type": "string", "minLength": 1 },
+          "score": { "type": "number", "minimum": 0, "maximum": 1 },
+          "rank": { "type": "integer", "minimum": 1 }
+        }
+      }
+    },
+    "created_utc": { "type": "string", "format": "date-time" }
+  }
+}

--- a/standards/thread-routing-policy-schema-v1.json
+++ b/standards/thread-routing-policy-schema-v1.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://projectlumina.org/thread-routing-policy-schema-v1.json",
+  "schema_version": "1.0.0",
+  "last_updated": "2026-07-19",
+  "title": "Thread Routing Policy Schema V1",
+  "description": "Configurable Business Ops policy for deterministic, scoped thread routing.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "policy_version", "defaults"],
+  "properties": {
+    "schema_version": { "const": "1.0.0" },
+    "policy_version": { "type": "integer", "minimum": 1 },
+    "defaults": { "$ref": "#/$defs/default_policy" },
+    "organizations": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/organization_override" }
+    }
+  },
+  "$defs": {
+    "policy_fields": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "attach_threshold": { "type": "number", "minimum": 0, "maximum": 1 },
+        "fork_threshold": { "type": "number", "minimum": 0, "maximum": 1 },
+        "ambiguity_margin": { "type": "number", "minimum": 0, "maximum": 1 },
+        "recap_interval_turns": { "type": "integer", "minimum": 1 },
+        "candidate_limit": { "type": "integer", "minimum": 1 },
+        "manual_only": { "type": "boolean" },
+        "require_operator_confirmation_for": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": ["attach_existing", "create_new", "fork_from", "ambiguous_attach"]
+          }
+        }
+      }
+    },
+    "default_policy": {
+      "allOf": [
+        { "$ref": "#/$defs/policy_fields" },
+        {
+          "required": [
+            "attach_threshold",
+            "fork_threshold",
+            "ambiguity_margin",
+            "recap_interval_turns",
+            "candidate_limit",
+            "manual_only",
+            "require_operator_confirmation_for"
+          ]
+        }
+      ]
+    },
+    "organization_override": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "attach_threshold": { "type": "number", "minimum": 0, "maximum": 1 },
+        "fork_threshold": { "type": "number", "minimum": 0, "maximum": 1 },
+        "ambiguity_margin": { "type": "number", "minimum": 0, "maximum": 1 },
+        "recap_interval_turns": { "type": "integer", "minimum": 1 },
+        "candidate_limit": { "type": "integer", "minimum": 1 },
+        "manual_only": { "type": "boolean" },
+        "require_operator_confirmation_for": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": ["attach_existing", "create_new", "fork_from", "ambiguous_attach"]
+          }
+        },
+        "sites": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/policy_fields" }
+        }
+      }
+    }
+  }
+}

--- a/standards/thread-summary-state-schema-v1.json
+++ b/standards/thread-summary-state-schema-v1.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://projectlumina.org/thread-summary-state-schema-v1.json",
+  "schema_version": "1.0.0",
+  "last_updated": "2026-07-19",
+  "title": "Thread Summary State Schema V1",
+  "description": "Transcript-free runtime continuity state for one scoped operational thread.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "thread_id",
+    "organization_id",
+    "site_id",
+    "actor_id",
+    "status",
+    "summary_record_id",
+    "recap_version",
+    "turn_start",
+    "turn_end",
+    "updated_utc"
+  ],
+  "properties": {
+    "schema_version": { "const": "1.0.0" },
+    "thread_id": { "type": "string", "minLength": 1 },
+    "organization_id": { "type": "string", "minLength": 1 },
+    "site_id": { "type": "string", "minLength": 1 },
+    "actor_id": { "type": "string", "minLength": 1 },
+    "device_id": { "type": ["string", "null"], "minLength": 1 },
+    "status": { "type": "string", "enum": ["open", "resolved", "escalated", "archived"] },
+    "summary_record_id": { "type": "string", "minLength": 1 },
+    "latest_routing_decision_id": { "type": ["string", "null"], "minLength": 1 },
+    "recap_version": { "type": "integer", "minimum": 1 },
+    "turn_start": { "type": "integer", "minimum": 1 },
+    "turn_end": { "type": "integer", "minimum": 1 },
+    "topics": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+    "updated_utc": { "type": "string", "format": "date-time" }
+  }
+}

--- a/tests/test_api_auth_integration.py
+++ b/tests/test_api_auth_integration.py
@@ -107,3 +107,54 @@ def test_users_endpoint_role_gating(client: TestClient) -> None:
 
     users_as_regular = client.get("/api/auth/users", headers={"Authorization": f"Bearer {user_token}"})
     assert users_as_regular.status_code == 403
+
+
+@pytest.mark.integration
+def test_user_can_switch_only_to_an_assigned_operating_context(client: TestClient) -> None:
+    root = client.post(
+        "/api/auth/register",
+        json={"username": "context-root", "password": "test-pass-123", "role": "user"},
+    ).json()
+    employee = client.post(
+        "/api/auth/register",
+        json={"username": "context-employee", "password": "test-pass-123", "role": "user"},
+    ).json()
+
+    assignment = client.patch(
+        f"/api/auth/users/{employee['user_id']}",
+        headers={"Authorization": f"Bearer {root['access_token']}"},
+        json={
+            "operating_memberships": [
+                {
+                    "organization_id": "org-1",
+                    "site_ids": ["site-1", "site-2"],
+                    "site_roles": {"site-1": "cashier", "site-2": "manager"},
+                }
+            ]
+        },
+    )
+    assert assignment.status_code == 200
+
+    login = client.post(
+        "/api/auth/login",
+        json={"username": "context-employee", "password": "test-pass-123"},
+    )
+    assert login.status_code == 200
+    assert login.json()["organization_id"] == "org-1"
+    assert login.json()["site_id"] == "site-1"
+
+    switched = client.post(
+        "/api/auth/operating-context",
+        headers={"Authorization": f"Bearer {login.json()['access_token']}"},
+        json={"organization_id": "org-1", "site_id": "site-2", "device_id": "device-9"},
+    )
+    assert switched.status_code == 200
+    assert switched.json()["site_id"] == "site-2"
+    assert switched.json()["device_id"] == "device-9"
+
+    forbidden = client.post(
+        "/api/auth/operating-context",
+        headers={"Authorization": f"Bearer {switched.json()['access_token']}"},
+        json={"organization_id": "org-1", "site_id": "site-3"},
+    )
+    assert forbidden.status_code == 403

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -133,6 +133,34 @@ def test_create_and_verify_jwt_success(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.unit
+def test_create_scoped_jwt_carries_one_active_operating_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(auth, "JWT_SECRET", "test-secret")
+    token = auth.create_scoped_jwt(
+        user_id="u-123",
+        role="user",
+        organization_id="org-1",
+        site_id="site-2",
+        device_id="device-3",
+        site_role="manager",
+    )
+
+    payload = auth.verify_scoped_jwt(token)
+    assert payload["organization_id"] == "org-1"
+    assert payload["site_id"] == "site-2"
+    assert payload["device_id"] == "device-3"
+    assert payload["site_role"] == "manager"
+
+
+@pytest.mark.unit
+def test_create_jwt_rejects_partial_operating_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(auth, "JWT_SECRET", "test-secret")
+    with pytest.raises(ValueError, match="supplied together"):
+        auth.create_jwt(user_id="u-123", role="user", organization_id="org-1")
+
+
+@pytest.mark.unit
 def test_create_jwt_rejects_invalid_role(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(auth, "JWT_SECRET", "test-secret")
     with pytest.raises(ValueError, match="Invalid role"):

--- a/tests/test_institutional_memory.py
+++ b/tests/test_institutional_memory.py
@@ -10,6 +10,8 @@ import pytest
 from lumina.retrieval.embedder import EMBEDDING_DIM
 from lumina.retrieval.institutional import InstitutionalMemoryIndexer, record_to_chunk
 from lumina.retrieval.vector_store import VectorStore
+from lumina.thread_routing.policy import ThreadRoutingPolicy
+from lumina.thread_routing.service import preflight_thread_route
 
 FIXTURE_PATH = Path(__file__).parent / "artifacts" / "institutional-memory-recall-fixture.json"
 
@@ -56,6 +58,21 @@ def _record(record_id: str = "memory-1") -> dict:
     }
 
 
+def _routing_policy() -> ThreadRoutingPolicy:
+    return ThreadRoutingPolicy(
+        policy_version=1,
+        attach_threshold=0.85,
+        fork_threshold=0.60,
+        ambiguity_margin=0.04,
+        recap_interval_turns=10,
+        candidate_limit=5,
+        manual_only=False,
+        require_operator_confirmation_for=("fork_from",),
+        organization_id="org-a",
+        site_id="site-1",
+    )
+
+
 def test_record_to_chunk_preserves_scope_and_provenance() -> None:
     chunk = record_to_chunk(_record())
     assert chunk.content_type == "institutional_memory"
@@ -63,6 +80,7 @@ def test_record_to_chunk_preserves_scope_and_provenance() -> None:
     assert chunk.site_id == "site-1"
     assert chunk.actor_id == "actor-1"
     assert chunk.record_id == "memory-1"
+    assert chunk.thread_id == "thread-1"
     assert chunk.provider == "erp"
     assert chunk.external_record_id == "wo-1"
     assert chunk.content_hash == record_to_chunk(_record()).content_hash
@@ -78,6 +96,17 @@ def test_indexer_deduplicates_by_content_hash(tmp_path) -> None:
     assert first == {"records_seen": 1, "records_indexed": 1, "records_skipped": 0}
     assert second == {"records_seen": 1, "records_indexed": 0, "records_skipped": 1}
     assert store.size == 1
+
+
+def test_vector_store_round_trip_preserves_institutional_thread_id(tmp_path) -> None:
+    store = VectorStore(tmp_path / "vs")
+    indexer = InstitutionalMemoryIndexer(store, _FakeEmbedder())
+    indexer.ingest([_record()])
+
+    restored = VectorStore(tmp_path / "vs")
+    restored.load()
+
+    assert restored._chunks[0].thread_id == "thread-1"
 
 
 def test_indexer_keeps_distinct_records_with_matching_summaries(tmp_path) -> None:
@@ -179,6 +208,45 @@ def test_recall_fixture_returns_only_the_scoped_expected_precedent(tmp_path) -> 
     )
 
     assert [result.chunk.record_id for result in results] == fixture["expected_record_ids"]
+
+
+def test_preflight_routes_to_same_site_thread_and_excludes_other_sites(tmp_path) -> None:
+    store = VectorStore(tmp_path / "vs")
+    indexer = InstitutionalMemoryIndexer(store, _FixtureEmbedder())
+    same_site = _record("summary-brake")
+    same_site["summary"] = "Brake maintenance work order is open."
+    same_site["thread_id"] = "thread-brake"
+    other_site = _record("summary-other-site")
+    other_site["site_id"] = "site-2"
+    other_site["summary"] = "Brake maintenance work order is open."
+    other_site["thread_id"] = "thread-other-site"
+    indexer.ingest([same_site, other_site])
+
+    preflight = preflight_thread_route(
+        "brake inspection update",
+        indexer=indexer,
+        policy=_routing_policy(),
+        actor_id="actor-1",
+    )
+
+    assert preflight.decision.decision == "attach_existing"
+    assert preflight.decision.thread_id == "thread-brake"
+    assert [candidate.thread_id for candidate in preflight.candidates] == ["thread-brake"]
+
+
+def test_preflight_forks_when_active_thread_has_no_scoped_match(tmp_path) -> None:
+    indexer = InstitutionalMemoryIndexer(VectorStore(tmp_path / "vs"), _FixtureEmbedder())
+
+    preflight = preflight_thread_route(
+        "unrelated inventory count",
+        indexer=indexer,
+        policy=_routing_policy(),
+        actor_id="actor-1",
+        active_thread_id="thread-active",
+    )
+
+    assert preflight.decision.decision == "fork_from"
+    assert preflight.decision.source_thread_id == "thread-active"
 
 
 @pytest.mark.parametrize("field", ["organization_id", "site_id", "actor_id"])

--- a/tests/test_thread_routing_api.py
+++ b/tests/test_thread_routing_api.py
@@ -1,0 +1,303 @@
+"""Integration tests for the authenticated thread-routing preflight API."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+from lumina.auth import auth
+from lumina.persistence.adapter import NullPersistenceAdapter
+from lumina.retrieval.embedder import EMBEDDING_DIM
+from lumina.retrieval.institutional import InstitutionalMemoryIndexer
+from lumina.retrieval.vector_store import VectorStore
+from lumina.thread_routing.bindings import create_thread_session_binding
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class _RecordingPersistence(NullPersistenceAdapter):
+    def __init__(self) -> None:
+        super().__init__()
+        self.records: list[dict] = []
+
+    def append_log_record(self, session_id, record, ledger_path=None) -> None:
+        self.records.append(dict(record))
+        super().append_log_record(session_id, record, ledger_path)
+
+
+class _FakeEmbedder:
+    @staticmethod
+    def _embed(text):
+        vector = np.zeros(EMBEDDING_DIM, dtype=np.float32)
+        if "brake" in text.lower():
+            vector[0] = 1.0
+        else:
+            vector[1] = 1.0
+        return vector
+
+    def embed_chunks(self, chunks):
+        return np.asarray([self._embed(chunk.text) for chunk in chunks], dtype=np.float32)
+
+    def embed_query(self, query):
+        return self._embed(query)
+
+
+def _load_api_module():
+    module_path = _REPO_ROOT / "src" / "lumina" / "api" / "server.py"
+    module_name = "lumina.api.server"
+    spec = importlib.util.spec_from_file_location(module_name, str(module_path))
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Could not load lumina-api-server module")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _summary(record_id: str, *, thread_id: str, site_id: str) -> dict:
+    return {
+        "record_type": "ThreadSummaryRecord",
+        "record_id": record_id,
+        "organization_id": "org-a",
+        "site_id": site_id,
+        "actor_id": "actor-a",
+        "thread_id": thread_id,
+        "summary": "Open brake inspection work order.",
+    }
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setenv("LUMINA_RUNTIME_CONFIG_PATH", "model-packs/education/cfg/runtime-config.yaml")
+    monkeypatch.delenv("LUMINA_DOMAIN_REGISTRY_PATH", raising=False)
+    mod = _load_api_module()
+    persistence = _RecordingPersistence()
+    mod.PERSISTENCE = persistence
+    monkeypatch.setattr(auth, "JWT_SECRET", "test-secret")
+
+    indexer = InstitutionalMemoryIndexer(VectorStore(tmp_path / "institutional"), _FakeEmbedder())
+    indexer.ingest([
+        _summary("summary-site-1", thread_id="thread-site-1", site_id="site-1"),
+        _summary("summary-site-2", thread_id="thread-site-2", site_id="site-2"),
+    ])
+    create_thread_session_binding(
+        persistence,
+        thread_id="thread-site-1",
+        session_id="session-thread-site-1",
+        organization_id="org-a",
+        site_id="site-1",
+        actor_id="actor-a",
+    )
+    import lumina.api.routes.thread_routing as route_module
+    monkeypatch.setattr(route_module, "_get_institutional_indexer", lambda: indexer)
+    route_module._pending_decisions.clear()
+    route_module._consumed_decision_ids.clear()
+    return TestClient(mod.app), persistence
+
+
+def _token(*, organization_id: str | None = "org-a", site_id: str | None = "site-1") -> str:
+    return auth.create_scoped_jwt(
+        user_id="actor-a",
+        role="user",
+        organization_id=organization_id,
+        site_id=site_id,
+    )
+
+
+@pytest.mark.integration
+def test_preflight_attaches_only_to_same_site_and_persists_evidence(client) -> None:
+    test_client, persistence = client
+    response = test_client.post(
+        "/api/thread-routing/preflight",
+        headers={"Authorization": f"Bearer {_token()}"},
+        json={"message": "brake inspection update", "session_id": "session-1"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["decision"] == "attach_existing"
+    assert body["thread_id"] == "thread-site-1"
+    assert [candidate["thread_id"] for candidate in body["candidates"]] == ["thread-site-1"]
+    assert len(persistence.records) == 1
+    assert persistence.records[0]["decision_id"] == body["decision_id"]
+    assert "message" not in persistence.records[0]
+    assert "transcript" not in persistence.records[0]
+
+
+@pytest.mark.integration
+def test_preflight_rejects_unscoped_token(client) -> None:
+    test_client, persistence = client
+    response = test_client.post(
+        "/api/thread-routing/preflight",
+        headers={"Authorization": f"Bearer {_token(organization_id=None, site_id=None)}"},
+        json={"message": "brake inspection update"},
+    )
+
+    assert response.status_code == 403
+    assert persistence.records == []
+
+
+@pytest.mark.integration
+def test_preflight_forks_without_a_matching_scoped_summary(client) -> None:
+    test_client, _ = client
+    response = test_client.post(
+        "/api/thread-routing/preflight",
+        headers={"Authorization": f"Bearer {_token()}"},
+        json={"message": "inventory count", "active_thread_id": "thread-active"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["decision"] == "fork_from"
+    assert response.json()["source_thread_id"] == "thread-active"
+
+
+@pytest.mark.integration
+def test_confirmation_persists_accepted_routing_intent_without_transcript(client) -> None:
+    test_client, persistence = client
+    preflight = test_client.post(
+        "/api/thread-routing/preflight",
+        headers={"Authorization": f"Bearer {_token()}"},
+        json={"message": "brake inspection update", "session_id": "session-1"},
+    )
+    assert preflight.status_code == 200
+
+    confirmation = test_client.post(
+        f"/api/thread-routing/{preflight.json()['decision_id']}/confirm",
+        headers={"Authorization": f"Bearer {_token()}"},
+        json={"action": "accept"},
+    )
+    assert confirmation.status_code == 200
+    assert confirmation.json()["decision_id"] == preflight.json()["decision_id"]
+    assert confirmation.json()["thread_id"] == "thread-site-1"
+    assert confirmation.json()["decision"] == "attach_existing"
+    assert confirmation.json()["operator_override"] is False
+    assert confirmation.json()["session_id"] == "session-thread-site-1"
+    assert len(persistence.records) == 2
+    evidence = persistence.records[1]["evidence_summary"]
+    assert evidence["preflight_decision_id"] == preflight.json()["decision_id"]
+    assert "message" not in evidence["routing_decision"]
+    assert "transcript" not in evidence["routing_decision"]
+
+
+@pytest.mark.integration
+def test_confirmation_can_create_new_thread_once(client) -> None:
+    test_client, _ = client
+    preflight = test_client.post(
+        "/api/thread-routing/preflight",
+        headers={"Authorization": f"Bearer {_token()}"},
+        json={"message": "brake inspection update"},
+    )
+    decision_id = preflight.json()["decision_id"]
+
+    confirmation = test_client.post(
+        f"/api/thread-routing/{decision_id}/confirm",
+        headers={"Authorization": f"Bearer {_token()}"},
+        json={"action": "create_new"},
+    )
+    assert confirmation.status_code == 200
+    assert confirmation.json()["decision"] == "create_new"
+    assert confirmation.json()["operator_override"] is True
+    assert confirmation.json()["thread_id"].startswith("thread-")
+
+    replay = test_client.post(
+        f"/api/thread-routing/{decision_id}/confirm",
+        headers={"Authorization": f"Bearer {_token()}"},
+        json={"action": "accept"},
+    )
+    assert replay.status_code == 409
+
+
+@pytest.mark.integration
+def test_confirmation_rejects_different_actor_or_active_context(client) -> None:
+    test_client, _ = client
+    preflight = test_client.post(
+        "/api/thread-routing/preflight",
+        headers={"Authorization": f"Bearer {_token()}"},
+        json={"message": "brake inspection update"},
+    )
+    decision_id = preflight.json()["decision_id"]
+
+    other_actor = auth.create_scoped_jwt(
+        user_id="actor-b", role="user", organization_id="org-a", site_id="site-1"
+    )
+    forbidden_actor = test_client.post(
+        f"/api/thread-routing/{decision_id}/confirm",
+        headers={"Authorization": f"Bearer {other_actor}"},
+        json={"action": "accept"},
+    )
+    assert forbidden_actor.status_code == 403
+
+    wrong_context = _token(site_id="site-2")
+    forbidden_context = test_client.post(
+        f"/api/thread-routing/{decision_id}/confirm",
+        headers={"Authorization": f"Bearer {wrong_context}"},
+        json={"action": "accept"},
+    )
+    assert forbidden_context.status_code == 403
+
+
+@pytest.mark.integration
+def test_confirmed_thread_selects_bound_chat_session(client, monkeypatch: pytest.MonkeyPatch) -> None:
+    test_client, _ = client
+    preflight = test_client.post(
+        "/api/thread-routing/preflight",
+        headers={"Authorization": f"Bearer {_token()}"},
+        json={"message": "brake inspection update"},
+    )
+    confirmation = test_client.post(
+        f"/api/thread-routing/{preflight.json()['decision_id']}/confirm",
+        headers={"Authorization": f"Bearer {_token()}"},
+        json={"action": "create_new"},
+    )
+    assert confirmation.status_code == 200
+    confirmed = confirmation.json()
+
+    def fake_process_message(session_id, *_args, **_kwargs):
+        from types import SimpleNamespace
+
+        chat_module._session_containers[session_id] = SimpleNamespace(
+            active_context=SimpleNamespace(turn_count=1)
+        )
+        return {
+            "session_id": session_id,
+            "response": "ok",
+            "action": "continue",
+            "prompt_type": "standard",
+            "escalated": False,
+            "domain_id": "_default",
+        }
+
+    import lumina.api.routes.chat as chat_module
+    monkeypatch.setattr(chat_module, "process_message", fake_process_message)
+    recap_calls: list[dict] = []
+
+    def fake_record_thread_recap(**kwargs):
+        recap_calls.append(kwargs)
+        return None
+
+    monkeypatch.setattr(chat_module, "record_thread_recap", fake_record_thread_recap)
+
+    response = test_client.post(
+        "/api/chat",
+        headers={"Authorization": f"Bearer {_token()}"},
+        json={"message": "continue", "thread_id": confirmed["thread_id"]},
+    )
+    assert response.status_code == 200
+    assert response.json()["session_id"] == confirmed["session_id"]
+    assert recap_calls[0]["thread_id"] == confirmed["thread_id"]
+    assert recap_calls[0]["turn_count"] == 1
+
+    mismatch = test_client.post(
+        "/api/chat",
+        headers={"Authorization": f"Bearer {_token()}"},
+        json={
+            "message": "continue",
+            "thread_id": confirmed["thread_id"],
+            "session_id": "other-session",
+        },
+    )
+    assert mismatch.status_code == 409

--- a/tests/test_thread_routing_api.py
+++ b/tests/test_thread_routing_api.py
@@ -212,6 +212,68 @@ def test_confirmation_can_create_new_thread_once(client) -> None:
 
 
 @pytest.mark.integration
+def test_preflight_prunes_expired_pending_and_consumed_decisions(client, monkeypatch: pytest.MonkeyPatch) -> None:
+    test_client, _ = client
+    import lumina.api.routes.thread_routing as route_module
+
+    expired_at = 10.0
+    route_module._pending_decisions["expired-pending"] = route_module._PendingDecision(
+        decision=route_module.ThreadRoutingDecision(
+            decision_id="expired-pending",
+            organization_id="org-a",
+            site_id="site-1",
+            actor_id="actor-a",
+            decision="create_new",
+            thread_id="thread-expired",
+            source_thread_id=None,
+            policy_version=1,
+            confidence=0.0,
+            rationale_code="no_match",
+            operator_confirmation_required=False,
+            operator_override=False,
+            candidates=(),
+        ),
+        session_id="session-expired",
+        active_thread_id=None,
+        expires_at=expired_at,
+    )
+    route_module._consumed_decision_ids["expired-consumed"] = expired_at
+    monkeypatch.setattr(route_module.time, "monotonic", lambda: expired_at + 1)
+
+    response = test_client.post(
+        "/api/thread-routing/preflight",
+        headers={"Authorization": f"Bearer {_token()}"},
+        json={"message": "brake inspection update"},
+    )
+
+    assert response.status_code == 200
+    assert "expired-pending" not in route_module._pending_decisions
+    assert "expired-consumed" not in route_module._consumed_decision_ids
+
+
+@pytest.mark.integration
+def test_confirmation_reports_expired_decision_as_gone(client, monkeypatch: pytest.MonkeyPatch) -> None:
+    test_client, _ = client
+    preflight = test_client.post(
+        "/api/thread-routing/preflight",
+        headers={"Authorization": f"Bearer {_token()}"},
+        json={"message": "brake inspection update"},
+    )
+    decision_id = preflight.json()["decision_id"]
+    import lumina.api.routes.thread_routing as route_module
+
+    expires_at = route_module._pending_decisions[decision_id].expires_at
+    monkeypatch.setattr(route_module.time, "monotonic", lambda: expires_at + 1)
+    response = test_client.post(
+        f"/api/thread-routing/{decision_id}/confirm",
+        headers={"Authorization": f"Bearer {_token()}"},
+        json={"action": "accept"},
+    )
+
+    assert response.status_code == 410
+
+
+@pytest.mark.integration
 def test_confirmation_rejects_different_actor_or_active_context(client) -> None:
     test_client, _ = client
     preflight = test_client.post(

--- a/tests/test_thread_routing_policy.py
+++ b/tests/test_thread_routing_policy.py
@@ -1,0 +1,120 @@
+"""Tests for Slice 28 Business Ops thread-routing policy resolution."""
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from lumina.thread_routing.policy import load_thread_routing_policy, resolve_thread_routing_policy
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+POLICY_PATH = REPO_ROOT / "model-packs" / "business-ops" / "cfg" / "thread-routing-policy.yaml"
+SCHEMA_PATH = REPO_ROOT / "standards" / "thread-routing-policy-schema-v1.json"
+
+
+def _config() -> dict:
+    return {
+        "schema_version": "1.0.0",
+        "policy_version": 3,
+        "defaults": {
+            "attach_threshold": 0.80,
+            "fork_threshold": 0.60,
+            "ambiguity_margin": 0.05,
+            "recap_interval_turns": 10,
+            "candidate_limit": 5,
+            "manual_only": False,
+            "require_operator_confirmation_for": ["fork_from"],
+        },
+        "organizations": {},
+    }
+
+
+@pytest.mark.unit
+def test_business_ops_policy_file_matches_schema() -> None:
+    import yaml
+
+    config = yaml.safe_load(POLICY_PATH.read_text(encoding="utf-8"))
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(config, schema)
+
+
+@pytest.mark.unit
+def test_policy_resolves_default_organization_and_site_precedence() -> None:
+    config = _config()
+    config["organizations"] = {
+        "org-a": {
+            "attach_threshold": 0.90,
+            "recap_interval_turns": 8,
+            "sites": {
+                "site-a": {
+                    "fork_threshold": 0.70,
+                    "candidate_limit": 3,
+                },
+            },
+        },
+    }
+
+    policy = resolve_thread_routing_policy(config, organization_id="org-a", site_id="site-a")
+
+    assert policy.attach_threshold == 0.90
+    assert policy.fork_threshold == 0.70
+    assert policy.recap_interval_turns == 8
+    assert policy.candidate_limit == 3
+    assert policy.ambiguity_margin == 0.05
+    assert policy.organization_id == "org-a"
+    assert policy.site_id == "site-a"
+
+
+@pytest.mark.unit
+def test_policy_does_not_leak_another_organization_override() -> None:
+    config = _config()
+    config["organizations"] = {"org-a": {"attach_threshold": 0.95}}
+
+    policy = resolve_thread_routing_policy(config, organization_id="org-b", site_id="site-a")
+
+    assert policy.attach_threshold == 0.80
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("organization_id,site_id", [("", "site-a"), ("org-a", "")])
+def test_policy_requires_authenticated_scope(organization_id: str, site_id: str) -> None:
+    with pytest.raises(ValueError, match="requires"):
+        resolve_thread_routing_policy(_config(), organization_id=organization_id, site_id=site_id)
+
+
+@pytest.mark.unit
+def test_policy_rejects_thresholds_that_weaken_fork_boundary() -> None:
+    config = _config()
+    config["defaults"]["fork_threshold"] = 0.81
+
+    with pytest.raises(ValueError, match="cannot exceed"):
+        resolve_thread_routing_policy(config, organization_id="org-a", site_id="site-a")
+
+
+@pytest.mark.unit
+def test_policy_rejects_unknown_override_fields() -> None:
+    config = deepcopy(_config())
+    config["organizations"] = {"org-a": {"skip_audit": True}}
+
+    with pytest.raises(ValueError, match="unknown fields"):
+        resolve_thread_routing_policy(config, organization_id="org-a", site_id="site-a")
+
+
+@pytest.mark.unit
+def test_policy_rejects_unknown_top_level_fields() -> None:
+    config = _config()
+    config["skip_audit"] = True
+
+    with pytest.raises(ValueError, match="unknown top-level"):
+        resolve_thread_routing_policy(config, organization_id="org-a", site_id="site-a")
+
+
+@pytest.mark.unit
+def test_policy_file_loads_through_core_yaml_loader() -> None:
+    policy = load_thread_routing_policy(POLICY_PATH, organization_id="org-a", site_id="site-a")
+
+    assert policy.policy_version == 1
+    assert policy.require_operator_confirmation_for == ("fork_from", "ambiguous_attach")

--- a/tests/test_thread_routing_router.py
+++ b/tests/test_thread_routing_router.py
@@ -1,0 +1,141 @@
+"""Deterministic routing-decision tests for Slice 28."""
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from lumina.thread_routing.policy import ThreadRoutingPolicy
+from lumina.thread_routing.router import ThreadCandidate, decide_thread_route
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = REPO_ROOT / "standards" / "thread-routing-decision-schema-v1.json"
+SUMMARY_STATE_SCHEMA_PATH = REPO_ROOT / "standards" / "thread-summary-state-schema-v1.json"
+
+
+def _policy(**overrides: object) -> ThreadRoutingPolicy:
+    values: dict[str, object] = {
+        "policy_version": 1,
+        "attach_threshold": 0.85,
+        "fork_threshold": 0.60,
+        "ambiguity_margin": 0.04,
+        "recap_interval_turns": 10,
+        "candidate_limit": 5,
+        "manual_only": False,
+        "require_operator_confirmation_for": ("fork_from",),
+        "organization_id": "org-a",
+        "site_id": "site-a",
+    }
+    values.update(overrides)
+    return ThreadRoutingPolicy(**values)  # type: ignore[arg-type]
+
+
+def _candidate(thread_id: str, score: float) -> ThreadCandidate:
+    return ThreadCandidate(thread_id, f"summary-{thread_id}", score)
+
+
+@pytest.mark.unit
+def test_high_confidence_candidate_attaches_with_stable_tie_break() -> None:
+    decision = decide_thread_route(
+        [_candidate("thread-b", 0.90), _candidate("thread-a", 0.90)],
+        _policy(),
+        actor_id="actor-a",
+        new_thread_id="unused",
+    )
+
+    assert decision.decision == "attach_existing"
+    assert decision.thread_id == "thread-a"
+    assert decision.rationale_code == "ambiguous_attach"
+    assert decision.operator_confirmation_required is True
+
+
+@pytest.mark.unit
+def test_unmatched_turn_creates_new_thread() -> None:
+    decision = decide_thread_route(
+        [_candidate("thread-a", 0.70)],
+        _policy(),
+        actor_id="actor-a",
+        new_thread_id="thread-new",
+    )
+
+    assert decision.decision == "create_new"
+    assert decision.thread_id == "thread-new"
+    assert decision.rationale_code == "no_eligible_match"
+
+
+@pytest.mark.unit
+def test_active_thread_drift_forks_with_explicit_source() -> None:
+    decision = decide_thread_route(
+        [_candidate("thread-active", 0.20)],
+        _policy(),
+        actor_id="actor-a",
+        active_thread_id="thread-active",
+        new_thread_id="thread-fork",
+    )
+
+    assert decision.decision == "fork_from"
+    assert decision.thread_id == "thread-fork"
+    assert decision.source_thread_id == "thread-active"
+    assert decision.rationale_code == "topic_drift"
+    assert decision.operator_confirmation_required is True
+
+
+@pytest.mark.unit
+def test_manual_policy_requires_confirmation_without_attaching() -> None:
+    decision = decide_thread_route(
+        [_candidate("thread-a", 0.99)],
+        _policy(manual_only=True),
+        actor_id="actor-a",
+        new_thread_id="thread-new",
+    )
+
+    assert decision.decision == "create_new"
+    assert decision.rationale_code == "manual_policy"
+    assert decision.operator_confirmation_required is True
+
+
+@pytest.mark.unit
+def test_decision_record_is_schema_valid_and_transcript_free() -> None:
+    decision = decide_thread_route(
+        [_candidate("thread-a", 0.90)],
+        _policy(),
+        actor_id="actor-a",
+        decision_id="decision-1",
+    )
+    record = decision.as_record(created_utc=datetime(2026, 7, 19, tzinfo=UTC))
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+    jsonschema.validate(record, schema, format_checker=jsonschema.FormatChecker())
+    assert "transcript" not in json.dumps(record).lower()
+
+
+@pytest.mark.unit
+def test_thread_summary_state_schema_is_transcript_free() -> None:
+    summary_state = {
+        "schema_version": "1.0.0",
+        "thread_id": "thread-a",
+        "organization_id": "org-a",
+        "site_id": "site-a",
+        "actor_id": "actor-a",
+        "status": "open",
+        "summary_record_id": "summary-a",
+        "latest_routing_decision_id": "decision-a",
+        "recap_version": 1,
+        "turn_start": 1,
+        "turn_end": 10,
+        "topics": ["brake inspection"],
+        "updated_utc": "2026-07-19T00:00:00Z",
+    }
+    schema = json.loads(SUMMARY_STATE_SCHEMA_PATH.read_text(encoding="utf-8"))
+
+    jsonschema.validate(summary_state, schema, format_checker=jsonschema.FormatChecker())
+    assert "transcript" not in json.dumps(summary_state).lower()
+
+
+@pytest.mark.unit
+def test_router_requires_actor_identity() -> None:
+    with pytest.raises(ValueError, match="actor_id"):
+        decide_thread_route([], _policy(), actor_id="")

--- a/tests/test_thread_routing_summaries.py
+++ b/tests/test_thread_routing_summaries.py
@@ -1,0 +1,95 @@
+"""Tests for transcript-free, cadence-controlled thread recap persistence."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+
+from lumina.persistence.adapter import NullPersistenceAdapter
+from lumina.thread_routing.policy import ThreadRoutingPolicy
+from lumina.thread_routing.summaries import record_thread_recap
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = REPO_ROOT / "standards" / "thread-summary-state-schema-v1.json"
+
+
+class _RecordingIndexer:
+    def __init__(self) -> None:
+        self.records: list[dict] = []
+
+    def ingest(self, records):
+        self.records.extend(records)
+        return {"records_seen": len(records), "records_indexed": len(records), "records_skipped": 0}
+
+
+def _policy() -> ThreadRoutingPolicy:
+    return ThreadRoutingPolicy(
+        policy_version=1,
+        attach_threshold=0.86,
+        fork_threshold=0.62,
+        ambiguity_margin=0.04,
+        recap_interval_turns=3,
+        candidate_limit=5,
+        manual_only=False,
+        require_operator_confirmation_for=("fork_from",),
+        organization_id="org-a",
+        site_id="site-a",
+    )
+
+
+def test_recap_indexes_first_turn_and_uses_schema_valid_transcript_free_state() -> None:
+    persistence = NullPersistenceAdapter()
+    indexer = _RecordingIndexer()
+    message = "Please inspect brake failure details today."
+
+    state = record_thread_recap(
+        persistence=persistence,
+        indexer=indexer,
+        policy=_policy(),
+        thread_id="thread-a",
+        actor_id="actor-a",
+        turn_count=1,
+        message=message,
+        action="continue",
+        domain_id="operations",
+    )
+
+    assert state is not None
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(state, schema, format_checker=jsonschema.FormatChecker())
+    assert len(indexer.records) == 1
+    serialized = json.dumps({"state": state, "record": indexer.records[0]}).lower()
+    assert message.lower() not in serialized
+    assert "transcript" not in serialized
+    assert "message" not in indexer.records[0]
+    assert indexer.records[0]["record_type"] == "ThreadSummaryRecord"
+    assert indexer.records[0]["thread_id"] == "thread-a"
+
+
+def test_recap_uses_configured_interval_and_advances_recap_version() -> None:
+    persistence = NullPersistenceAdapter()
+    indexer = _RecordingIndexer()
+    first = record_thread_recap(
+        persistence=persistence, indexer=indexer, policy=_policy(),
+        thread_id="thread-a", actor_id="actor-a", turn_count=1,
+        message="inventory review", action="continue", domain_id="operations",
+    )
+    skipped = record_thread_recap(
+        persistence=persistence, indexer=indexer, policy=_policy(),
+        thread_id="thread-a", actor_id="actor-a", turn_count=3,
+        message="inventory count", action="continue", domain_id="operations",
+    )
+    second = record_thread_recap(
+        persistence=persistence, indexer=indexer, policy=_policy(),
+        thread_id="thread-a", actor_id="actor-a", turn_count=4,
+        message="inventory reconciliation", action="continue", domain_id="operations",
+    )
+
+    assert first is not None
+    assert skipped is None
+    assert second is not None
+    assert second["recap_version"] == 2
+    assert second["turn_start"] == 2
+    assert second["turn_end"] == 4
+    assert len(indexer.records) == 2


### PR DESCRIPTION
## Architectural Compliance Checklist

- [x] **Tests Passed:** Full Python, frontend, Linux Compose, and browser regression suites passed. The legacy unscoped pre-integration chat scenario is documented below as a compatibility gap.
- [x] **CTL Integrity:** Preflight and confirmation routes append auditable, transcript-free `TraceEvent` evidence; API coverage verifies confirmation ledger records and replay protection.
- [x] **Domain Separation:** Routing policy values live in the Business Ops configuration surface; the System layer retains scope, audit, and authority enforcement.
- [x] **Pseudonymity:** Thread recap state and routing evidence retain identifiers, hashes, topics, decisions, and scores only; they do not persist raw chat transcript content.
- [x] **Traceability Proof:** `tests/test_thread_routing_api.py` verifies the emitted `thread_routing_confirmed` TraceEvent and its scoped routing evidence.

---

## Description of Changes

Implements Slice 28 semantic thread routing and marks the roadmap slice delivered.

- Adds scoped Business Ops routing policy, schema contracts, deterministic router, retrieval preflight, operator confirmation/override, replay protection, and System-ledger evidence.
- Adds active organization/site JWT context and membership switching; binds transcript seals and session resume to that active context.
- Adds scope- and actor-bound logical thread-to-runtime-session bindings plus transcript-free rolling recap summaries indexed for continuity.
- Wires the React client to preflight, present attach/new/fork choices when needed, and send confirmed `thread_id`/`session_id` values to chat.
- Adds Docker Compose Linux backend, frontend-unit, and Playwright E2E targets. Aligns the Playwright container image with the lockfile-resolved browser version.

## Type of Change

- [x] ⚙️ **Core Engine**
- [x] 📦 **Domain Pack**
- [ ] 🛠️ **Tool Adapter**
- [x] 🛡️ **Governance/Security**
- [x] 📖 **Documentation**

## Validation

- Host Python: `5,370 passed, 2 skipped, 1 warning`
- Host Vitest: `113 passed`
- Linux Compose backend: `5,370 passed, 2 skipped, 1 warning`; `86.77%` coverage against the `85%` gate
- Linux Compose frontend unit: passed
- Linux Compose Playwright E2E: `1 passed`
- Frontend production build, Compose configuration, manifest integrity, and `git diff --check`: passed

### Known Pre-Integration Harness Gap

`run-preintegration-scenarios.ps1` successfully reaches the local API after seeding the temporary system-physics commitment, but its legacy unauthenticated/unscoped `/api/chat` scenario now fails with `CommitmentRecord requires scope fields: organization_id, site_id`. Slice 28 intentionally makes scope a hard boundary. The harness needs a follow-up update to authenticate with an active organization/site context before it can be checked as passing.

---

## Traceability Proof (Mandatory)

Representative redacted routing confirmation evidence asserted by `tests/test_thread_routing_api.py`:

```json
{
  "record_type": "TraceEvent",
  "event_type": "thread_routing_confirmed",
  "actor_id": "<authenticated-actor>",
  "metadata": {
    "organization_id": "<active-organization>",
    "site_id": "<active-site>",
    "routing": {
      "decision": "attach_existing",
      "thread_id": "<logical-thread-id>",
      "session_id": "<bound-runtime-session-id>",
      "policy_version": 1,
      "operator_override": false
    }
  }
}
```

## Domain Impact

Validated against the existing domain-agnostic Python regression suite and the scoped routing fixtures. Policy values are isolated to `model-packs/business-ops`; the System layer enforces scope and audit boundaries.