### PR TITLE
Add scoped decision precedent escalation

### DIFF
--- a/docs/MANIFEST.yaml
+++ b/docs/MANIFEST.yaml
@@ -137,10 +137,10 @@ artifacts:
 - path: docs/roadmap/slices/29-decision-precedent-confidence-and-escalation.md
   type: doc
   section: 0
-  doc_version: 1.0.0
+  doc_version: 0.2.0
   status: planned
-  last_updated: 2026-07-11
-  sha256: 9739b4e1557efc2a5a730b4b24e4595ca5bb65b909036caae93daebc81092587
+  last_updated: 2026-07-20
+  sha256: 9b5a025494cc1f9a008960ed95e53af3f6b87b8f174b427c3e7a1f7a1f78944d
 - path: docs/roadmap/slices/30-erpnext-adapter-foundation-and-fixtures.md
   type: doc
   section: 0
@@ -1262,12 +1262,36 @@ artifacts:
   status: active
   last_updated: 2026-07-15
   sha256: 314288783f2368817fb92c54c71fceb46046fa93410b61603517a00ebcf55cd9
-- path: standards/thread-summary-record-schema-v1.json
+- path: standards/precedent-match-schema-v1.json
   type: schema
   doc_version: 1.0.0
   status: active
-  last_updated: 2026-07-15
-  sha256: 1bde3f792774b36a45a41b461c466fe12ac3112181bdd165eb7bd6b412949731
+  last_updated: 2026-07-20
+  sha256: 949a32f06142c0cb7f3943fcd6a5e058db531f05e82ef31b061f5ab071e8973c
+- path: standards/decision-confidence-score-schema-v1.json
+  type: schema
+  doc_version: 1.0.0
+  status: active
+  last_updated: 2026-07-20
+  sha256: f1e69ab3cefc4d3a5ab2aa780f307ad59836305208ef7de0d748fb70ca0292e1
+- path: standards/business-escalation-packet-schema-v1.json
+  type: schema
+  doc_version: 1.0.0
+  status: active
+  last_updated: 2026-07-20
+  sha256: d512b3a966472acc8545394bfa8a808fdee262df210d7d77a41efff723148c50
+- path: standards/decision-precedent-policy-schema-v1.json
+  type: schema
+  doc_version: 1.0.0
+  status: active
+  last_updated: 2026-07-20
+  sha256: f26486a4f3b83955c670a499902107301afcf4ab6769b65f9ca2927d660a9069
+- path: standards/thread-summary-record-schema-v1.json
+  type: schema
+  doc_version: 1.0.1
+  status: active
+  last_updated: 2026-07-20
+  sha256: 3c29292fb70196adb591e77d96e746e96b0576a97adcfa1ac7d7431155e5a28a
 - path: standards/business-system-event-mirror-record-schema-v1.json
   type: schema
   doc_version: 1.0.0
@@ -1382,6 +1406,12 @@ artifacts:
   status: active
   last_updated: 2026-07-19
   sha256: 0e8b48ec4a6d86e900ab0778664a248c80345a16f7f2805d9ab442e98d957a7f
+- path: model-packs/business-ops/cfg/decision-precedent-policy.yaml
+  type: config
+  doc_version: 1.0.0
+  status: active
+  last_updated: 2026-07-20
+  sha256: 97433cb5c0bd13f7bffd5efcf8d4cec4567b9b0d83e6bf9006e7beafa2a6a039
 - path: model-packs/system/cfg/ui-config.yaml
   type: config
   doc_version: 1.0.0

--- a/docs/roadmap/slices/29-decision-precedent-confidence-and-escalation.md
+++ b/docs/roadmap/slices/29-decision-precedent-confidence-and-escalation.md
@@ -2,73 +2,178 @@
 title: "Slice 29 — Decision Precedent, Confidence, and Escalation"
 slice: 29
 status: planned
-version: 0.1.0
-last_updated: 2026-07-11
+version: 0.2.0
+last_updated: 2026-07-20
 ---
 
 ## Purpose
 
-Codify institutional decision precedent retrieval and confidence scoring so Lumina can propose proxy decisions when safe and escalate high-liability or low-confidence cases to human authority.
+Codify scoped institutional decision-precedent retrieval and deterministic
+confidence scoring so Lumina can make an auditable recommendation when policy
+permits and create a human-approval packet when confidence or risk requires it.
 
 ## Scope
 
-- Define confidence model inputs:
-  - precedent similarity,
-  - scope match,
-  - recency,
-  - risk class.
-- Define action policy tiers:
-  - suggest-only,
-  - require confirmation,
-  - mandatory escalation.
-- Define escalation packet shape for owner/manager approvals.
+- Consume only Slice 28 institutional `ThreadSummaryRecord` evidence through a
+  hard organization/site filter; raw user messages, assistant responses, and
+  transcripts are never precedent inputs or persisted evidence.
+- Define a pure, deterministic confidence evaluation from policy-owned inputs:
+  - strongest same-scope precedent similarity,
+  - bounded recency band derived from record metadata,
+  - policy-declared risk class,
+  - explicit missing-evidence penalties.
+- Define policy tiers with deterministic precedence:
+  - `suggest_only`,
+  - `require_confirmation`,
+  - `mandatory_escalation`.
+- Define a transcript-free business escalation packet that references precedent
+  record IDs, policy version, component scores, and selected tier.
+- Reuse existing System Log `EscalationRecord` lifecycle for mandatory
+  escalation; Slice 29 creates evidence and a pending approval request only.
 
 ## Out of Scope
 
 - Push-notification transport implementation.
 - Final mobile UX.
-- Automated execution of high-liability physical operations.
+- Connector resolution, provider-specific APIs, or ERP mutations (Slices 30-34).
+- Automated execution, final approval, or commitment of any business action.
+- LLM-generated confidence, implicit risk classification, or unbounded transcript
+  summarization.
 
 ## Required Changes
 
-- Add precedent evaluation policy spec and confidence rubric.
-- Add escalation contract spec aligned with existing system escalation records.
-- Add deterministic fixtures demonstrating safe/unsafe recommendation boundaries.
+- Add a policy-only Business Ops `decision-precedent-policy.yaml` with default,
+  organization, and site overrides. System code resolves policy but cannot relax
+  scope, audit, or escalation requirements.
+- Add pure `decision_precedent` evaluation logic that retrieves eligible
+  same-scope summaries, calculates component scores, chooses a policy tier, and
+  emits no side effect.
+- Add an authenticated scoped preflight endpoint that persists a transcript-free
+  `TraceEvent` for every evaluation.
+- Add a confirmation endpoint only for `require_confirmation`; it records
+  explicit operator intent but must not execute a business operation.
+- For `mandatory_escalation`, create a pending existing `EscalationRecord` whose
+  evidence summary carries the schema-valid business escalation packet and whose
+  organization/site scope matches the active JWT context.
+- Add deterministic fixtures for high-confidence/low-risk recommendation,
+  ambiguous or stale precedent confirmation, missing-precedent escalation, and
+  high-risk escalation.
 
 ## New/Changed Contracts
 
-- New `precedent_match` contract with provenance and confidence evidence.
-- New `decision_confidence_score` contract with transparent component fields.
-- New `business_escalation_packet` contract for targeted approval requests.
+- New `precedent_match` contract containing only scope, summary record identity,
+  thread identity, similarity, recency band, and rank.
+- New `decision_confidence_score` contract containing versioned component scores,
+  penalties, final score, selected policy tier, and deterministic rationale codes.
+- New `business_escalation_packet` contract for targeted owner/manager approval;
+  it references decision and precedent record IDs and forbids raw transcript,
+  prompt, credential, and provider-specific mutation data.
+- New `decision_precedent_policy` contract with threshold bands, risk-class
+  precedence, recency bands, candidate limits, and confirmation/escalation rules.
+- Existing `EscalationRecord` remains the lifecycle record. Slice 29 extends
+  only its allowed structured evidence/metadata payload, avoiding a breaking
+  change to the generic escalation schema.
 
 ## Files Likely Touched
 
-- `standards/escalation-record-schema-v1.json`
-- `standards/domain-evidence-schema-v1.json`
-- `src/lumina/orchestrator/actor_resolver.py`
-- `src/lumina/api/pipeline/response.py`
-- `tests/test_*escalation*` (new)
+- `model-packs/business-ops/cfg/decision-precedent-policy.yaml` (new)
+- `standards/precedent-match-schema-v1.json` (new)
+- `standards/decision-confidence-score-schema-v1.json` (new)
+- `standards/business-escalation-packet-schema-v1.json` (new)
+- `standards/decision-precedent-policy-schema-v1.json` (new)
+- `src/lumina/decision_precedent/` (new pure policy, scorer, and retrieval service)
+- `src/lumina/api/routes/decision_precedent.py` (new scoped preflight/confirm API)
+- `src/lumina/api/models.py` and `src/lumina/api/server.py`
+- `tests/test_decision_precedent_policy.py` (new)
+- `tests/test_decision_precedent_service.py` (new)
+- `tests/test_decision_precedent_api.py` (new)
 - `docs/roadmap/slices/29-decision-precedent-confidence-and-escalation.md`
 
 ## Acceptance Criteria
 
-- Confidence score is deterministic for fixed fixture inputs.
-- Policy tiers are enforceable without model-side hidden behavior.
-- High-risk decisions always escalate.
-- Decision rationale is audit-visible and replayable.
+- Candidate retrieval cannot cross organization/site scope and never emits raw
+  transcript content in a response, System Log record, persisted packet, or
+  vector metadata.
+- Fixed fixtures produce identical ordered precedent matches, component scores,
+  tier, rationale code, and packet identity inputs across runs.
+- Policy precedence is site override, organization override, then Business Ops
+  default; invalid thresholds, invalid risk classes, and cross-scope overrides
+  are rejected.
+- High-risk and missing-precedent evaluations always select `mandatory_escalation`
+  regardless of similarity score; `require_confirmation` never executes an action.
+- Every preflight appends a scoped, transcript-free `TraceEvent`; mandatory
+  escalation appends a schema-valid pending `EscalationRecord` that references
+  the decision evidence.
+- A user cannot view, confirm, or resolve a packet outside their active scope or
+  authority; the existing escalation resolver remains the only approval lifecycle.
+- Slice 28 routing, chat, transcript-resume, and existing escalation regression
+  tests remain green.
 
 ## Tests
 
-- Deterministic score calculation tests.
-- Policy threshold tests (`suggest`, `confirm`, `escalate`).
-- Regression tests for existing standing-order escalation paths.
+- Unit: score component arithmetic, penalty application, stable candidate ordering,
+  and rationale/tier selection using fixed metadata fixtures.
+- Unit: default/organization/site policy precedence; malformed policy, unsafe
+  threshold ordering, and unsupported risk class rejection.
+- Service: same-site retrieval success; cross-site and non-institutional record
+  exclusion; stale/missing precedent handling without raw-text persistence.
+- API: active-context requirement, preflight trace evidence, confirmation replay
+  protection, mandatory-escalation packet creation, and cross-actor/scope denial.
+- Schema: positive and negative validation for all four new contracts, including
+  explicit rejection of transcript, credential, and provider mutation fields.
+- Regression: existing escalation list/detail/resolve behavior, Slice 28 routing
+  API/recap behavior, and transcript resume scope mismatch rejection.
 
 ## Ledger/Governance Impact
 
-- Adds formal precedent-evidence and confidence traces to governance packets.
-- Preserves System Pack authority boundaries; recommendations do not equal activation.
+- Adds formal, transcript-free precedent and confidence traces plus pending
+  approval packets to the System Log.
+- Business Ops owns configurable score/risk thresholds; the System layer owns
+  scope validation, authorization, append-only evidence, and escalation lifecycle.
+- Recommendations, confirmations, and escalations never grant connector,
+  mutation, approval, or commitment authority.
 
 ## Follow-Up Slices
 
 - Slice 30: canonical business-system contracts and capability taxonomy.
 - Slice 31: connector registry and capability routing.
+
+## Implementation Plan
+
+1. Define and validate the four contracts plus the Business Ops policy file;
+  register them in `docs/MANIFEST.yaml` before adding runtime behavior.
+2. Implement pure policy resolution and scoring with fixed fixtures. No API,
+  persistence, or System Log mutation is permitted in this phase.
+3. Add scope-filtered precedent retrieval over Slice 28 summary records and
+  produce schema-valid evaluation evidence without retaining query text.
+4. Add authenticated preflight/confirmation routes, System Log trace events,
+  and pending `EscalationRecord` creation. Reuse existing escalation resolution
+  rather than creating a parallel approval system.
+5. Add frontend transport only after the API and policy matrix pass; the initial
+  UI is a compact recommendation/confirmation/escalation state, not a redesign.
+6. Run focused policy/service/API/schema tests, then the full Python, frontend,
+  Docker Compose Linux, and manifest-integrity suites before marking delivered.
+
+## PR Handoff
+
+**Proposed title:** `Add scoped decision precedent escalation`
+
+**Scope:** Add deterministic, policy-configured precedent evaluation over Slice
+28 summaries; expose scoped recommendation/confirmation/escalation preflight;
+write transcript-free audit evidence; create no connector or business mutation.
+
+**Acceptance checklist:**
+
+- [ ] Score and tier are deterministic for fixed fixtures.
+- [ ] Scope filtering prevents cross-organization/site precedent or packet access.
+- [ ] High-risk and missing-precedent cases always create a pending escalation.
+- [ ] Confirmation is explicit, replay-protected, and cannot execute a business action.
+- [ ] All evidence is schema-valid, transcript-free, and System-log committed.
+- [ ] Existing Slice 28 routing and escalation lifecycle regressions pass.
+
+**Test checklist:**
+
+- [ ] Policy, scoring, service, API, and schema tests.
+- [ ] Existing routing, auth, transcript-resume, and escalation regression tests.
+- [ ] Full Python suite, frontend suite/build, Docker Compose Linux backend/unit/E2E,
+    manifest integrity, and `git diff --check`.

--- a/model-packs/business-ops/cfg/decision-precedent-policy.yaml
+++ b/model-packs/business-ops/cfg/decision-precedent-policy.yaml
@@ -1,0 +1,23 @@
+# version: 1.0.0
+# last_updated: 2026-07-20
+schema_version: 1.0.0
+policy_version: 1
+
+# Business Ops owns these operating thresholds. System code always enforces
+# active organization/site scope, audit evidence, and escalation lifecycle.
+defaults:
+  candidate_limit: 5
+  suggest_threshold: 0.88
+  confirmation_threshold: 0.70
+  stale_after_days: 90
+  stale_penalty: 0.18
+  missing_precedent_penalty: 1.0
+  high_risk_classes:
+    - financial
+    - safety
+    - legal
+  confirmation_risk_classes:
+    - operational
+
+# Configuration precedence is site, organization, then these defaults.
+organizations: {}

--- a/src/lumina/api/dependencies.py
+++ b/src/lumina/api/dependencies.py
@@ -1,0 +1,43 @@
+"""Shared authenticated dependencies for scope-bound API routes."""
+from __future__ import annotations
+
+import functools
+from typing import Any
+
+from fastapi import Depends, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+
+from lumina.api import config as _cfg
+from lumina.api.middleware import _bearer_scheme, get_current_user, require_auth
+from lumina.auth.operating_context import operating_context_from_claims
+from lumina.retrieval.embedder import DocEmbedder
+from lumina.retrieval.institutional import InstitutionalMemoryIndexer
+from lumina.retrieval.vector_store import VectorStore
+
+_INSTITUTIONAL_INDEX_DIR = _cfg._REPO_ROOT / "data" / "retrieval-index" / "institutional-memory"
+
+
+async def get_authenticated_user(
+    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
+) -> dict[str, Any]:
+    """Return a verified authenticated user from the bearer-token flow."""
+    return require_auth(await get_current_user(credentials))
+
+
+def get_active_operating_context(
+    user: dict[str, Any] = Depends(get_authenticated_user),
+) -> dict[str, str | None]:
+    """Require an active organization and site for scope-bound operations."""
+    try:
+        context = operating_context_from_claims(user)
+    except ValueError as exc:
+        raise HTTPException(status_code=403, detail="Invalid active operating context") from exc
+    if context is None:
+        raise HTTPException(status_code=403, detail="An active organization and site context is required")
+    return context
+
+
+@functools.lru_cache(maxsize=1)
+def get_institutional_indexer() -> InstitutionalMemoryIndexer:
+    """Build and share the local institutional-memory indexer lazily."""
+    return InstitutionalMemoryIndexer(VectorStore(_INSTITUTIONAL_INDEX_DIR), DocEmbedder())

--- a/src/lumina/api/models.py
+++ b/src/lumina/api/models.py
@@ -86,6 +86,34 @@ class ThreadRoutingConfirmationResponse(BaseModel):
     session_id: str
 
 
+# ── Decision precedent ───────────────────────────────────────
+
+class DecisionPrecedentPreflightRequest(BaseModel):
+    message: str = Field(min_length=1)
+    risk_class: str = Field(min_length=1)
+    session_id: str | None = None
+
+
+class DecisionPrecedentPreflightResponse(BaseModel):
+    confidence_record_id: str
+    organization_id: str
+    site_id: str
+    actor_id: str
+    policy_version: int
+    risk_class: str
+    final_score: float
+    tier: str
+    rationale_codes: list[str]
+    confirmation_required: bool
+    escalation_record_id: str | None = None
+
+
+class DecisionPrecedentConfirmationResponse(BaseModel):
+    confirmation_id: str
+    confidence_record_id: str
+    tier: str
+
+
 # ── Holodeck Sandbox ─────────────────────────────────────────
 
 class HolodeckSimulateRequest(BaseModel):

--- a/src/lumina/api/routes/chat.py
+++ b/src/lumina/api/routes/chat.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import functools
 import logging
 import time
 import uuid
@@ -13,6 +12,7 @@ from fastapi.security import HTTPAuthorizationCredentials
 from starlette.concurrency import run_in_threadpool
 
 from lumina.api import config as _cfg
+from lumina.api.dependencies import get_institutional_indexer
 from lumina.api.middleware import _bearer_scheme, get_current_user
 from lumina.api.models import ChatRequest, ChatResponse
 from lumina.api.processing import process_message
@@ -23,24 +23,12 @@ from lumina.system_log.commit_guard import requires_log_commit
 from lumina.thread_routing.bindings import load_thread_session_binding
 from lumina.thread_routing.policy import load_thread_routing_policy
 from lumina.thread_routing.summaries import record_thread_recap
-from lumina.retrieval.embedder import DocEmbedder
-from lumina.retrieval.institutional import InstitutionalMemoryIndexer
-from lumina.retrieval.vector_store import VectorStore
 
 log = logging.getLogger("lumina-api")
 
 router = APIRouter()
 
 _THREAD_ROUTING_POLICY_PATH = _cfg._REPO_ROOT / "model-packs" / "business-ops" / "cfg" / "thread-routing-policy.yaml"
-_INSTITUTIONAL_INDEX_DIR = _cfg._REPO_ROOT / "data" / "retrieval-index" / "institutional-memory"
-
-
-@functools.lru_cache(maxsize=1)
-def _get_institutional_indexer() -> InstitutionalMemoryIndexer:
-    """Build the recap indexer lazily and reuse it across routed chat turns."""
-    return InstitutionalMemoryIndexer(VectorStore(_INSTITUTIONAL_INDEX_DIR), DocEmbedder())
-
-
 def _get_accessible_domain_ids(
     user: dict[str, Any],
     routing_map: dict[str, dict[str, Any]],
@@ -279,7 +267,7 @@ async def chat(
             await run_in_threadpool(
                 record_thread_recap,
                 persistence=_cfg.PERSISTENCE,
-                indexer=_get_institutional_indexer(),
+                indexer=get_institutional_indexer(),
                 policy=policy,
                 thread_id=req.thread_id,
                 actor_id=str(user["sub"]),

--- a/src/lumina/api/routes/decision_precedent.py
+++ b/src/lumina/api/routes/decision_precedent.py
@@ -1,37 +1,34 @@
 """Authenticated, scope-safe decision-precedent preflight API."""
 from __future__ import annotations
 
-import functools
 import time
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException
-from fastapi.security import HTTPAuthorizationCredentials
 from starlette.concurrency import run_in_threadpool
 
 from lumina.api import config as _cfg
-from lumina.api.middleware import _bearer_scheme, get_current_user, require_auth
+from lumina.api.dependencies import (
+    get_active_operating_context,
+    get_authenticated_user,
+    get_institutional_indexer,
+)
 from lumina.api.models import (
     DecisionPrecedentConfirmationResponse,
     DecisionPrecedentPreflightRequest,
     DecisionPrecedentPreflightResponse,
 )
-from lumina.auth.operating_context import operating_context_from_claims
 from lumina.decision_precedent.policy import load_decision_precedent_policy
 from lumina.decision_precedent.scorer import DecisionConfidenceScore
 from lumina.decision_precedent.service import evaluate_decision_precedent
-from lumina.retrieval.embedder import DocEmbedder
-from lumina.retrieval.institutional import InstitutionalMemoryIndexer
-from lumina.retrieval.vector_store import VectorStore
 from lumina.system_log.admin_operations import build_trace_event
 from lumina.system_log.commit_guard import requires_log_commit
 
 router = APIRouter()
 
 _POLICY_PATH = _cfg._REPO_ROOT / "model-packs" / "business-ops" / "cfg" / "decision-precedent-policy.yaml"
-_DEFAULT_INDEX_DIR = _cfg._REPO_ROOT / "data" / "retrieval-index" / "institutional-memory"
 _PENDING_CONFIRMATION_TTL_SECONDS = 300
 _ESCALATION_TARGET_ROLE = "business-ops:owner-manager"
 
@@ -47,12 +44,6 @@ _pending_confirmations: dict[str, _PendingConfirmation] = {}
 _consumed_confirmation_ids: dict[str, float] = {}
 
 
-@functools.lru_cache(maxsize=1)
-def _get_institutional_indexer() -> InstitutionalMemoryIndexer:
-    """Build the local institutional index provider lazily on first preflight."""
-    return InstitutionalMemoryIndexer(VectorStore(_DEFAULT_INDEX_DIR), DocEmbedder())
-
-
 def _prune_expired_confirmations(now: float | None = None) -> None:
     """Bound in-memory confirmation state to its fixed replay-protection TTL."""
     current = time.monotonic() if now is None else now
@@ -62,16 +53,6 @@ def _prune_expired_confirmations(now: float | None = None) -> None:
     for record_id, expires_at in list(_consumed_confirmation_ids.items()):
         if expires_at <= current:
             del _consumed_confirmation_ids[record_id]
-
-
-def _active_context(user: dict[str, object]) -> dict[str, str | None]:
-    try:
-        context = operating_context_from_claims(user)
-    except ValueError as exc:
-        raise HTTPException(status_code=403, detail="Invalid active operating context") from exc
-    if context is None:
-        raise HTTPException(status_code=403, detail="An active organization and site context is required")
-    return context
 
 
 def _escalation_session_id(session_id: str | None, confidence_record_id: str) -> str:
@@ -133,11 +114,10 @@ def _build_escalation_record(
 @requires_log_commit
 async def preflight(
     req: DecisionPrecedentPreflightRequest,
-    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
+    user: dict[str, object] = Depends(get_authenticated_user),
+    context: dict[str, str | None] = Depends(get_active_operating_context),
 ) -> DecisionPrecedentPreflightResponse:
     """Evaluate scoped precedent and create audit evidence without executing work."""
-    user = require_auth(await get_current_user(credentials))
-    context = _active_context(user)
     try:
         policy = load_decision_precedent_policy(
             _POLICY_PATH,
@@ -147,7 +127,7 @@ async def preflight(
         score = await run_in_threadpool(
             evaluate_decision_precedent,
             req.message,
-            indexer=_get_institutional_indexer(),
+            indexer=get_institutional_indexer(),
             policy=policy,
             actor_id=str(user["sub"]),
             risk_class=req.risk_class,
@@ -209,11 +189,10 @@ async def preflight(
 @requires_log_commit
 async def confirm(
     confidence_record_id: str,
-    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
+    user: dict[str, object] = Depends(get_authenticated_user),
+    context: dict[str, str | None] = Depends(get_active_operating_context),
 ) -> DecisionPrecedentConfirmationResponse:
     """Record explicit confirmation intent; this endpoint cannot execute a business action."""
-    user = require_auth(await get_current_user(credentials))
-    context = _active_context(user)
     _prune_expired_confirmations()
     if confidence_record_id in _consumed_confirmation_ids:
         raise HTTPException(status_code=409, detail="Decision precedent confirmation has already been applied")

--- a/src/lumina/api/routes/decision_precedent.py
+++ b/src/lumina/api/routes/decision_precedent.py
@@ -1,0 +1,255 @@
+"""Authenticated, scope-safe decision-precedent preflight API."""
+from __future__ import annotations
+
+import functools
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+from starlette.concurrency import run_in_threadpool
+
+from lumina.api import config as _cfg
+from lumina.api.middleware import _bearer_scheme, get_current_user, require_auth
+from lumina.api.models import (
+    DecisionPrecedentConfirmationResponse,
+    DecisionPrecedentPreflightRequest,
+    DecisionPrecedentPreflightResponse,
+)
+from lumina.auth.operating_context import operating_context_from_claims
+from lumina.decision_precedent.policy import load_decision_precedent_policy
+from lumina.decision_precedent.scorer import DecisionConfidenceScore
+from lumina.decision_precedent.service import evaluate_decision_precedent
+from lumina.retrieval.embedder import DocEmbedder
+from lumina.retrieval.institutional import InstitutionalMemoryIndexer
+from lumina.retrieval.vector_store import VectorStore
+from lumina.system_log.admin_operations import build_trace_event
+from lumina.system_log.commit_guard import requires_log_commit
+
+router = APIRouter()
+
+_POLICY_PATH = _cfg._REPO_ROOT / "model-packs" / "business-ops" / "cfg" / "decision-precedent-policy.yaml"
+_DEFAULT_INDEX_DIR = _cfg._REPO_ROOT / "data" / "retrieval-index" / "institutional-memory"
+_PENDING_CONFIRMATION_TTL_SECONDS = 300
+_ESCALATION_TARGET_ROLE = "business-ops:owner-manager"
+
+
+@dataclass(frozen=True)
+class _PendingConfirmation:
+    score: DecisionConfidenceScore
+    session_id: str
+    expires_at: float
+
+
+_pending_confirmations: dict[str, _PendingConfirmation] = {}
+_consumed_confirmation_ids: dict[str, float] = {}
+
+
+@functools.lru_cache(maxsize=1)
+def _get_institutional_indexer() -> InstitutionalMemoryIndexer:
+    """Build the local institutional index provider lazily on first preflight."""
+    return InstitutionalMemoryIndexer(VectorStore(_DEFAULT_INDEX_DIR), DocEmbedder())
+
+
+def _prune_expired_confirmations(now: float | None = None) -> None:
+    """Bound in-memory confirmation state to its fixed replay-protection TTL."""
+    current = time.monotonic() if now is None else now
+    for record_id, pending in list(_pending_confirmations.items()):
+        if pending.expires_at <= current:
+            del _pending_confirmations[record_id]
+    for record_id, expires_at in list(_consumed_confirmation_ids.items()):
+        if expires_at <= current:
+            del _consumed_confirmation_ids[record_id]
+
+
+def _active_context(user: dict[str, object]) -> dict[str, str | None]:
+    try:
+        context = operating_context_from_claims(user)
+    except ValueError as exc:
+        raise HTTPException(status_code=403, detail="Invalid active operating context") from exc
+    if context is None:
+        raise HTTPException(status_code=403, detail="An active organization and site context is required")
+    return context
+
+
+def _escalation_session_id(session_id: str | None, confidence_record_id: str) -> str:
+    """Produce a schema-valid opaque session identifier for the escalation record."""
+    seed = session_id or confidence_record_id
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"decision-precedent:{seed}"))
+
+
+def _build_escalation_record(
+    score: DecisionConfidenceScore,
+    *,
+    session_id: str | None,
+    created_utc: datetime | None = None,
+) -> dict[str, object]:
+    """Create a standard pending EscalationRecord without business-action content."""
+    timestamp = created_utc or datetime.now(UTC)
+    packet_id = str(uuid.uuid4())
+    packet = {
+        "packet_id": packet_id,
+        "organization_id": score.organization_id,
+        "site_id": score.site_id,
+        "actor_id": score.actor_id,
+        "confidence_record_id": score.record_id,
+        "policy_version": score.policy_version,
+        "risk_class": score.risk_class,
+        "tier": "mandatory_escalation",
+        "target_role": _ESCALATION_TARGET_ROLE,
+        "status": "pending",
+        "precedent_summary_record_ids": [
+            match.summary_record_id for match in score.precedent_matches
+        ],
+        "created_utc": timestamp.astimezone(UTC).isoformat().replace("+00:00", "Z"),
+    }
+    return {
+        "record_type": "EscalationRecord",
+        "record_id": str(uuid.uuid4()),
+        "prev_record_hash": "genesis",
+        "timestamp_utc": timestamp.astimezone(UTC).isoformat().replace("+00:00", "Z"),
+        "session_id": _escalation_session_id(session_id, score.record_id),
+        "escalating_actor_id": score.actor_id,
+        "target_meta_authority_id": _ESCALATION_TARGET_ROLE,
+        "organization_id": score.organization_id,
+        "site_id": score.site_id,
+        "trigger": "Decision precedent policy requires human approval.",
+        "trigger_type": "other",
+        "evidence_summary": {
+            "decision_confidence_score": score.as_record(created_utc=timestamp),
+            "business_escalation_packet": packet,
+        },
+        "status": "pending",
+        "proposed_action": "Human approval is required before any business action.",
+    }
+
+
+@router.post(
+    "/api/decision-precedent/preflight",
+    response_model=DecisionPrecedentPreflightResponse,
+)
+@requires_log_commit
+async def preflight(
+    req: DecisionPrecedentPreflightRequest,
+    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
+) -> DecisionPrecedentPreflightResponse:
+    """Evaluate scoped precedent and create audit evidence without executing work."""
+    user = require_auth(await get_current_user(credentials))
+    context = _active_context(user)
+    try:
+        policy = load_decision_precedent_policy(
+            _POLICY_PATH,
+            organization_id=str(context["organization_id"]),
+            site_id=str(context["site_id"]),
+        )
+        score = await run_in_threadpool(
+            evaluate_decision_precedent,
+            req.message,
+            indexer=_get_institutional_indexer(),
+            policy=policy,
+            actor_id=str(user["sub"]),
+            risk_class=req.risk_class,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    ledger_session_id = req.session_id or "decision-precedent"
+    score_record = score.as_record()
+    trace_event = build_trace_event(
+        session_id=ledger_session_id,
+        actor_id=str(user["sub"]),
+        event_type="other",
+        decision="decision_precedent_evaluated",
+        evidence_summary={"decision_confidence_score": score_record},
+    )
+    await run_in_threadpool(
+        _cfg.PERSISTENCE.append_log_record,
+        ledger_session_id,
+        trace_event,
+        _cfg.PERSISTENCE.get_system_ledger_path(ledger_session_id),
+    )
+    escalation_record_id: str | None = None
+    if score.tier == "mandatory_escalation":
+        escalation = _build_escalation_record(score, session_id=req.session_id)
+        escalation_record_id = str(escalation["record_id"])
+        await run_in_threadpool(
+            _cfg.PERSISTENCE.append_log_record,
+            ledger_session_id,
+            escalation,
+            _cfg.PERSISTENCE.get_system_ledger_path(ledger_session_id),
+        )
+    elif score.tier == "require_confirmation":
+        _prune_expired_confirmations()
+        _pending_confirmations[score.record_id] = _PendingConfirmation(
+            score=score,
+            session_id=ledger_session_id,
+            expires_at=time.monotonic() + _PENDING_CONFIRMATION_TTL_SECONDS,
+        )
+    return DecisionPrecedentPreflightResponse(
+        confidence_record_id=score.record_id,
+        organization_id=score.organization_id,
+        site_id=score.site_id,
+        actor_id=score.actor_id,
+        policy_version=score.policy_version,
+        risk_class=score.risk_class,
+        final_score=score.final_score,
+        tier=score.tier,
+        rationale_codes=list(score.rationale_codes),
+        confirmation_required=score.tier == "require_confirmation",
+        escalation_record_id=escalation_record_id,
+    )
+
+
+@router.post(
+    "/api/decision-precedent/{confidence_record_id}/confirm",
+    response_model=DecisionPrecedentConfirmationResponse,
+)
+@requires_log_commit
+async def confirm(
+    confidence_record_id: str,
+    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
+) -> DecisionPrecedentConfirmationResponse:
+    """Record explicit confirmation intent; this endpoint cannot execute a business action."""
+    user = require_auth(await get_current_user(credentials))
+    context = _active_context(user)
+    _prune_expired_confirmations()
+    if confidence_record_id in _consumed_confirmation_ids:
+        raise HTTPException(status_code=409, detail="Decision precedent confirmation has already been applied")
+    pending = _pending_confirmations.get(confidence_record_id)
+    if pending is None:
+        raise HTTPException(status_code=404, detail="Decision precedent confirmation was not found")
+    if pending.expires_at <= time.monotonic():
+        del _pending_confirmations[confidence_record_id]
+        raise HTTPException(status_code=410, detail="Decision precedent confirmation has expired")
+    score = pending.score
+    if score.actor_id != user["sub"]:
+        raise HTTPException(status_code=403, detail="Decision precedent confirmation belongs to another actor")
+    if score.organization_id != context["organization_id"] or score.site_id != context["site_id"]:
+        raise HTTPException(status_code=403, detail="Decision precedent confirmation is outside the active context")
+    confirmation_id = str(uuid.uuid4())
+    event = build_trace_event(
+        session_id=pending.session_id,
+        actor_id=str(user["sub"]),
+        event_type="other",
+        decision="decision_precedent_confirmed",
+        evidence_summary={
+            "confirmation_id": confirmation_id,
+            "confidence_record_id": score.record_id,
+            "tier": score.tier,
+        },
+    )
+    await run_in_threadpool(
+        _cfg.PERSISTENCE.append_log_record,
+        pending.session_id,
+        event,
+        _cfg.PERSISTENCE.get_system_ledger_path(pending.session_id),
+    )
+    del _pending_confirmations[confidence_record_id]
+    _consumed_confirmation_ids[confidence_record_id] = time.monotonic() + _PENDING_CONFIRMATION_TTL_SECONDS
+    return DecisionPrecedentConfirmationResponse(
+        confirmation_id=confirmation_id,
+        confidence_record_id=score.record_id,
+        tier=score.tier,
+    )

--- a/src/lumina/api/routes/thread_routing.py
+++ b/src/lumina/api/routes/thread_routing.py
@@ -1,17 +1,19 @@
 """Authenticated, scope-safe thread-routing preflight API."""
 from __future__ import annotations
 
-import functools
 import time
 import uuid
 from dataclasses import dataclass, replace
 
 from fastapi import APIRouter, Depends, HTTPException
-from fastapi.security import HTTPAuthorizationCredentials
 from starlette.concurrency import run_in_threadpool
 
 from lumina.api import config as _cfg
-from lumina.api.middleware import _bearer_scheme, get_current_user, require_auth
+from lumina.api.dependencies import (
+    get_active_operating_context,
+    get_authenticated_user,
+    get_institutional_indexer,
+)
 from lumina.api.models import (
     ThreadRoutingCandidateResponse,
     ThreadRoutingConfirmationRequest,
@@ -19,10 +21,6 @@ from lumina.api.models import (
     ThreadRoutingPreflightRequest,
     ThreadRoutingPreflightResponse,
 )
-from lumina.auth.operating_context import operating_context_from_claims
-from lumina.retrieval.embedder import DocEmbedder
-from lumina.retrieval.institutional import InstitutionalMemoryIndexer
-from lumina.retrieval.vector_store import VectorStore
 from lumina.system_log.commit_guard import requires_log_commit
 from lumina.system_log.admin_operations import build_trace_event
 from lumina.thread_routing.policy import load_thread_routing_policy
@@ -36,7 +34,6 @@ from lumina.thread_routing.bindings import (
 router = APIRouter()
 
 _POLICY_PATH = _cfg._REPO_ROOT / "model-packs" / "business-ops" / "cfg" / "thread-routing-policy.yaml"
-_DEFAULT_INDEX_DIR = _cfg._REPO_ROOT / "data" / "retrieval-index" / "institutional-memory"
 _PENDING_DECISION_TTL_SECONDS = 300
 
 
@@ -50,12 +47,6 @@ class _PendingDecision:
 
 _pending_decisions: dict[str, _PendingDecision] = {}
 _consumed_decision_ids: dict[str, float] = {}
-
-
-@functools.lru_cache(maxsize=1)
-def _get_institutional_indexer() -> InstitutionalMemoryIndexer:
-    """Build the local institutional index provider lazily on first preflight."""
-    return InstitutionalMemoryIndexer(VectorStore(_DEFAULT_INDEX_DIR), DocEmbedder())
 
 
 def _prune_expired_decisions(now: float | None = None) -> None:
@@ -93,16 +84,6 @@ def _response_from_record(record: dict[str, object]) -> ThreadRoutingPreflightRe
         operator_override=bool(record["operator_override"]),
         candidates=candidates,
     )
-
-
-def _active_context(user: dict[str, object]) -> dict[str, str | None]:
-    try:
-        context = operating_context_from_claims(user)
-    except ValueError as exc:
-        raise HTTPException(status_code=403, detail="Invalid active operating context") from exc
-    if context is None:
-        raise HTTPException(status_code=403, detail="An active organization and site context is required")
-    return context
 
 
 def _resolve_confirmation(
@@ -158,12 +139,10 @@ def _resolve_confirmation(
 @requires_log_commit
 async def preflight(
     req: ThreadRoutingPreflightRequest,
-    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
+    user: dict[str, object] = Depends(get_authenticated_user),
+    context: dict[str, str | None] = Depends(get_active_operating_context),
 ) -> ThreadRoutingPreflightResponse:
     """Return an auditable attach/new/fork recommendation without mutating a session."""
-    user = require_auth(await get_current_user(credentials))
-    context = _active_context(user)
-
     try:
         policy = load_thread_routing_policy(
             _POLICY_PATH,
@@ -173,7 +152,7 @@ async def preflight(
         preflight_result = await run_in_threadpool(
             preflight_thread_route,
             req.message,
-            indexer=_get_institutional_indexer(),
+            indexer=get_institutional_indexer(),
             policy=policy,
             actor_id=str(user["sub"]),
             active_thread_id=req.active_thread_id,
@@ -207,11 +186,10 @@ async def preflight(
 async def confirm(
     decision_id: str,
     req: ThreadRoutingConfirmationRequest,
-    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
+    user: dict[str, object] = Depends(get_authenticated_user),
+    context: dict[str, str | None] = Depends(get_active_operating_context),
 ) -> ThreadRoutingConfirmationResponse:
     """Confirm or override a preflight decision as auditable routing intent."""
-    user = require_auth(await get_current_user(credentials))
-    context = _active_context(user)
     current_time = time.monotonic()
     for consumed_id, expires_at in list(_consumed_decision_ids.items()):
         if expires_at <= current_time:

--- a/src/lumina/api/server.py
+++ b/src/lumina/api/server.py
@@ -137,6 +137,7 @@ from lumina.api.routes.admin import (  # noqa: E402
 from lumina.api.routes.auth import router as auth_router  # noqa: E402
 from lumina.api.routes.chat import router as chat_router  # noqa: E402
 from lumina.api.routes.thread_routing import router as thread_routing_router  # noqa: E402
+from lumina.api.routes.decision_precedent import router as decision_precedent_router  # noqa: E402
 from lumina.api.routes.system_log import router as system_log_router  # noqa: E402
 from lumina.api.routes.dashboard import router as dashboard_router  # noqa: E402
 from lumina.api.routes.domain import router as domain_router  # noqa: E402
@@ -211,6 +212,7 @@ app.add_middleware(_InFlightCounterMiddleware)
 # Register route groups
 app.include_router(chat_router)
 app.include_router(thread_routing_router)
+app.include_router(decision_precedent_router)
 app.include_router(auth_router)
 app.include_router(system_router)
 app.include_router(domain_router)

--- a/src/lumina/core/policy_validation.py
+++ b/src/lumina/core/policy_validation.py
@@ -1,0 +1,18 @@
+"""Shared validation for versioned Business Ops policy documents."""
+from __future__ import annotations
+
+from typing import Any
+
+
+_TOP_LEVEL_POLICY_FIELDS = frozenset({"schema_version", "policy_version", "defaults", "organizations"})
+
+
+def validate_policy_header(config: dict[str, Any], *, policy_name: str) -> dict[str, Any]:
+    """Reject unsupported policy document shapes before resolving overrides."""
+    unknown = set(config) - _TOP_LEVEL_POLICY_FIELDS
+    if unknown:
+        names = ", ".join(sorted(unknown))
+        raise ValueError(f"{policy_name} policy has unknown top-level fields: {names}")
+    if config.get("schema_version") != "1.0.0":
+        raise ValueError(f"unsupported {policy_name} policy schema_version")
+    return config

--- a/src/lumina/decision_precedent/__init__.py
+++ b/src/lumina/decision_precedent/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic, scope-safe decision precedent evaluation."""

--- a/src/lumina/decision_precedent/policy.py
+++ b/src/lumina/decision_precedent/policy.py
@@ -1,0 +1,164 @@
+"""Business Ops decision-precedent policy loading and safe override resolution."""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from lumina.core.yaml_loader import load_yaml
+
+_POLICY_FIELDS = frozenset({
+    "candidate_limit",
+    "suggest_threshold",
+    "confirmation_threshold",
+    "stale_after_days",
+    "stale_penalty",
+    "missing_precedent_penalty",
+    "high_risk_classes",
+    "confirmation_risk_classes",
+})
+_RISK_CLASS_FIELDS = frozenset({"high_risk_classes", "confirmation_risk_classes"})
+
+
+@dataclass(frozen=True)
+class DecisionPrecedentPolicy:
+    """Resolved deterministic policy for one authenticated organization/site."""
+
+    policy_version: int
+    candidate_limit: int
+    suggest_threshold: float
+    confirmation_threshold: float
+    stale_after_days: int
+    stale_penalty: float
+    missing_precedent_penalty: float
+    high_risk_classes: tuple[str, ...]
+    confirmation_risk_classes: tuple[str, ...]
+    organization_id: str
+    site_id: str
+
+
+def _require_scope(identifier: str, field_name: str) -> str:
+    if not isinstance(identifier, str) or not identifier.strip():
+        raise ValueError(f"decision precedent requires {field_name}")
+    return identifier.strip()
+
+
+def _as_mapping(value: Any, field_name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"decision precedent policy {field_name} must be a mapping")
+    return value
+
+
+def _merge_policy(base: dict[str, Any], override: dict[str, Any], field_name: str) -> dict[str, Any]:
+    unknown = set(override) - _POLICY_FIELDS
+    if unknown:
+        names = ", ".join(sorted(unknown))
+        raise ValueError(f"decision precedent policy {field_name} has unknown fields: {names}")
+    merged = dict(base)
+    merged.update(override)
+    return merged
+
+
+def _number(value: Any, field_name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value):
+        raise ValueError(f"decision precedent policy {field_name} must be a finite number")
+    numeric = float(value)
+    if not 0 <= numeric <= 1:
+        raise ValueError(f"decision precedent policy {field_name} must be between 0 and 1")
+    return numeric
+
+
+def _positive_integer(value: Any, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"decision precedent policy {field_name} must be a positive integer")
+    return value
+
+
+def _risk_classes(value: Any, field_name: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or any(not isinstance(item, str) or not item.strip() for item in value):
+        raise ValueError(f"decision precedent policy {field_name} must contain non-empty strings")
+    normalized = tuple(item.strip() for item in value)
+    if len(set(normalized)) != len(normalized):
+        raise ValueError(f"decision precedent policy {field_name} must be unique")
+    return normalized
+
+
+def _validate_resolved_policy(
+    policy: dict[str, Any], *, policy_version: int, organization_id: str, site_id: str
+) -> DecisionPrecedentPolicy:
+    missing = _POLICY_FIELDS - set(policy)
+    if missing:
+        names = ", ".join(sorted(missing))
+        raise ValueError(f"decision precedent policy defaults are missing: {names}")
+    if isinstance(policy_version, bool) or not isinstance(policy_version, int) or policy_version < 1:
+        raise ValueError("decision precedent policy policy_version must be a positive integer")
+    suggest_threshold = _number(policy["suggest_threshold"], "suggest_threshold")
+    confirmation_threshold = _number(policy["confirmation_threshold"], "confirmation_threshold")
+    if confirmation_threshold > suggest_threshold:
+        raise ValueError("decision precedent policy confirmation_threshold cannot exceed suggest_threshold")
+    high_risk_classes = _risk_classes(policy["high_risk_classes"], "high_risk_classes")
+    confirmation_risk_classes = _risk_classes(
+        policy["confirmation_risk_classes"], "confirmation_risk_classes"
+    )
+    overlap = set(high_risk_classes) & set(confirmation_risk_classes)
+    if overlap:
+        raise ValueError("decision precedent policy risk classes cannot overlap")
+    return DecisionPrecedentPolicy(
+        policy_version=policy_version,
+        candidate_limit=_positive_integer(policy["candidate_limit"], "candidate_limit"),
+        suggest_threshold=suggest_threshold,
+        confirmation_threshold=confirmation_threshold,
+        stale_after_days=_positive_integer(policy["stale_after_days"], "stale_after_days"),
+        stale_penalty=_number(policy["stale_penalty"], "stale_penalty"),
+        missing_precedent_penalty=_number(
+            policy["missing_precedent_penalty"], "missing_precedent_penalty"
+        ),
+        high_risk_classes=high_risk_classes,
+        confirmation_risk_classes=confirmation_risk_classes,
+        organization_id=organization_id,
+        site_id=site_id,
+    )
+
+
+def resolve_decision_precedent_policy(
+    config: dict[str, Any], *, organization_id: str, site_id: str
+) -> DecisionPrecedentPolicy:
+    """Resolve site, organization, then default policy for authenticated scope."""
+    organization_id = _require_scope(organization_id, "organization_id")
+    site_id = _require_scope(site_id, "site_id")
+    allowed_top_level = {"schema_version", "policy_version", "defaults", "organizations"}
+    unknown = set(config) - allowed_top_level
+    if unknown:
+        names = ", ".join(sorted(unknown))
+        raise ValueError(f"decision precedent policy has unknown top-level fields: {names}")
+    if config.get("schema_version") != "1.0.0":
+        raise ValueError("unsupported decision precedent policy schema_version")
+    defaults = _as_mapping(config.get("defaults"), "defaults")
+    resolved = _merge_policy({}, defaults, "defaults")
+    organizations = _as_mapping(config.get("organizations", {}), "organizations")
+    organization_override = _as_mapping(
+        organizations.get(organization_id, {}), f"organizations.{organization_id}"
+    )
+    sites = _as_mapping(organization_override.get("sites", {}), f"organizations.{organization_id}.sites")
+    organization_fields = {key: value for key, value in organization_override.items() if key != "sites"}
+    resolved = _merge_policy(resolved, organization_fields, f"organizations.{organization_id}")
+    site_override = _as_mapping(
+        sites.get(site_id, {}), f"organizations.{organization_id}.sites.{site_id}"
+    )
+    resolved = _merge_policy(resolved, site_override, f"organizations.{organization_id}.sites.{site_id}")
+    return _validate_resolved_policy(
+        resolved,
+        policy_version=config.get("policy_version"),
+        organization_id=organization_id,
+        site_id=site_id,
+    )
+
+
+def load_decision_precedent_policy(
+    config_path: str | Path, *, organization_id: str, site_id: str
+) -> DecisionPrecedentPolicy:
+    """Load and resolve policy from a Business Ops configuration file."""
+    return resolve_decision_precedent_policy(
+        load_yaml(config_path), organization_id=organization_id, site_id=site_id
+    )

--- a/src/lumina/decision_precedent/policy.py
+++ b/src/lumina/decision_precedent/policy.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from lumina.core.policy_validation import validate_policy_header
 from lumina.core.yaml_loader import load_yaml
 
 _POLICY_FIELDS = frozenset({
@@ -127,13 +128,7 @@ def resolve_decision_precedent_policy(
     """Resolve site, organization, then default policy for authenticated scope."""
     organization_id = _require_scope(organization_id, "organization_id")
     site_id = _require_scope(site_id, "site_id")
-    allowed_top_level = {"schema_version", "policy_version", "defaults", "organizations"}
-    unknown = set(config) - allowed_top_level
-    if unknown:
-        names = ", ".join(sorted(unknown))
-        raise ValueError(f"decision precedent policy has unknown top-level fields: {names}")
-    if config.get("schema_version") != "1.0.0":
-        raise ValueError("unsupported decision precedent policy schema_version")
+    config = validate_policy_header(config, policy_name="decision precedent")
     defaults = _as_mapping(config.get("defaults"), "defaults")
     resolved = _merge_policy({}, defaults, "defaults")
     organizations = _as_mapping(config.get("organizations", {}), "organizations")

--- a/src/lumina/decision_precedent/scorer.py
+++ b/src/lumina/decision_precedent/scorer.py
@@ -1,0 +1,180 @@
+"""Pure deterministic confidence scoring over already scope-filtered evidence."""
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Literal
+
+from lumina.decision_precedent.policy import DecisionPrecedentPolicy
+
+DecisionTier = Literal["suggest_only", "require_confirmation", "mandatory_escalation"]
+RecencyBand = Literal["current", "stale"]
+
+
+@dataclass(frozen=True)
+class PrecedentCandidate:
+    """A scope-filtered summary candidate without transcript content."""
+
+    summary_record_id: str
+    thread_id: str
+    similarity: float
+    created_utc: datetime
+
+    def __post_init__(self) -> None:
+        if not self.summary_record_id or not self.thread_id:
+            raise ValueError("precedent candidates require summary and thread identifiers")
+        if isinstance(self.similarity, bool) or not isinstance(self.similarity, (int, float)):
+            raise ValueError("precedent candidate similarity must be numeric")
+        if not 0 <= self.similarity <= 1:
+            raise ValueError("precedent candidate similarity must be between 0 and 1")
+        if self.created_utc.tzinfo is None:
+            raise ValueError("precedent candidate created_utc must include a timezone")
+
+
+@dataclass(frozen=True)
+class PrecedentMatch:
+    """A normalized, rank-stable source record used for confidence evidence."""
+
+    summary_record_id: str
+    thread_id: str
+    similarity: float
+    created_utc: datetime
+    recency_band: RecencyBand
+    rank: int
+
+
+@dataclass(frozen=True)
+class DecisionConfidenceScore:
+    """Fully explainable score with a policy-enforced action tier."""
+
+    record_id: str
+    organization_id: str
+    site_id: str
+    actor_id: str
+    policy_version: int
+    risk_class: str
+    similarity_score: float
+    recency_penalty: float
+    missing_precedent_penalty: float
+    final_score: float
+    tier: DecisionTier
+    rationale_codes: tuple[str, ...]
+    precedent_matches: tuple[PrecedentMatch, ...]
+
+    def as_record(self, *, created_utc: datetime | None = None) -> dict[str, object]:
+        """Serialize schema-valid evidence without raw input text or transcript data."""
+        timestamp = created_utc or datetime.now(UTC)
+        return {
+            "record_id": self.record_id,
+            "organization_id": self.organization_id,
+            "site_id": self.site_id,
+            "actor_id": self.actor_id,
+            "policy_version": self.policy_version,
+            "risk_class": self.risk_class,
+            "similarity_score": self.similarity_score,
+            "recency_penalty": self.recency_penalty,
+            "missing_precedent_penalty": self.missing_precedent_penalty,
+            "final_score": self.final_score,
+            "tier": self.tier,
+            "rationale_codes": list(self.rationale_codes),
+            "precedent_matches": [
+                {
+                    "record_id": f"{self.record_id}:match:{match.rank}",
+                    "organization_id": self.organization_id,
+                    "site_id": self.site_id,
+                    "actor_id": self.actor_id,
+                    "summary_record_id": match.summary_record_id,
+                    "thread_id": match.thread_id,
+                    "similarity": match.similarity,
+                    "created_utc": match.created_utc.astimezone(UTC).isoformat().replace("+00:00", "Z"),
+                    "recency_band": match.recency_band,
+                    "rank": match.rank,
+                }
+                for match in self.precedent_matches
+            ],
+            "created_utc": timestamp.astimezone(UTC).isoformat().replace("+00:00", "Z"),
+        }
+
+
+def _require_identifier(value: str, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"decision confidence requires {field_name}")
+    return value.strip()
+
+
+def _ordered_matches(
+    candidates: list[PrecedentCandidate], policy: DecisionPrecedentPolicy, *, evaluated_utc: datetime
+) -> tuple[PrecedentMatch, ...]:
+    cutoff = evaluated_utc - __import__("datetime").timedelta(days=policy.stale_after_days)
+    ordered = sorted(candidates, key=lambda candidate: (-candidate.similarity, candidate.summary_record_id))
+    matches: list[PrecedentMatch] = []
+    for rank, candidate in enumerate(ordered[: policy.candidate_limit], start=1):
+        band: RecencyBand = "stale" if candidate.created_utc.astimezone(UTC) < cutoff else "current"
+        matches.append(PrecedentMatch(
+            summary_record_id=candidate.summary_record_id,
+            thread_id=candidate.thread_id,
+            similarity=float(candidate.similarity),
+            created_utc=candidate.created_utc,
+            recency_band=band,
+            rank=rank,
+        ))
+    return tuple(matches)
+
+
+def score_decision_precedent(
+    candidates: list[PrecedentCandidate],
+    policy: DecisionPrecedentPolicy,
+    *,
+    actor_id: str,
+    risk_class: str,
+    evaluated_utc: datetime | None = None,
+    record_id: str | None = None,
+) -> DecisionConfidenceScore:
+    """Score candidates deterministically; risk and absence always override similarity."""
+    actor_id = _require_identifier(actor_id, "actor_id")
+    risk_class = _require_identifier(risk_class, "risk_class")
+    now = evaluated_utc or datetime.now(UTC)
+    if now.tzinfo is None:
+        raise ValueError("decision confidence evaluated_utc must include a timezone")
+    matches = _ordered_matches(candidates, policy, evaluated_utc=now)
+    best = matches[0] if matches else None
+    similarity_score = best.similarity if best else 0.0
+    recency_penalty = policy.stale_penalty if best and best.recency_band == "stale" else 0.0
+    missing_penalty = policy.missing_precedent_penalty if best is None else 0.0
+    final_score = round(max(0.0, similarity_score - recency_penalty - missing_penalty), 6)
+    rationale: list[str] = []
+    if risk_class in policy.high_risk_classes:
+        tier: DecisionTier = "mandatory_escalation"
+        rationale.append("high_risk_class")
+    elif best is None:
+        tier = "mandatory_escalation"
+        rationale.append("missing_precedent")
+    elif final_score >= policy.suggest_threshold and risk_class not in policy.confirmation_risk_classes:
+        tier = "suggest_only"
+        rationale.append("high_confidence_precedent")
+    elif final_score >= policy.confirmation_threshold:
+        tier = "require_confirmation"
+        rationale.append("confirmation_threshold")
+    else:
+        tier = "mandatory_escalation"
+        rationale.append("insufficient_confidence")
+    if best and best.recency_band == "stale":
+        rationale.append("stale_precedent")
+    if risk_class in policy.confirmation_risk_classes and tier == "require_confirmation":
+        rationale.append("confirmation_risk_class")
+    return DecisionConfidenceScore(
+        record_id=record_id or str(uuid.uuid4()),
+        organization_id=policy.organization_id,
+        site_id=policy.site_id,
+        actor_id=actor_id,
+        policy_version=policy.policy_version,
+        risk_class=risk_class,
+        similarity_score=similarity_score,
+        recency_penalty=recency_penalty,
+        missing_precedent_penalty=missing_penalty,
+        final_score=final_score,
+        tier=tier,
+        rationale_codes=tuple(rationale),
+        precedent_matches=matches,
+    )

--- a/src/lumina/decision_precedent/scorer.py
+++ b/src/lumina/decision_precedent/scorer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Literal
 
 from lumina.decision_precedent.policy import DecisionPrecedentPolicy
@@ -106,7 +106,7 @@ def _require_identifier(value: str, field_name: str) -> str:
 def _ordered_matches(
     candidates: list[PrecedentCandidate], policy: DecisionPrecedentPolicy, *, evaluated_utc: datetime
 ) -> tuple[PrecedentMatch, ...]:
-    cutoff = evaluated_utc - __import__("datetime").timedelta(days=policy.stale_after_days)
+    cutoff = evaluated_utc - timedelta(days=policy.stale_after_days)
     ordered = sorted(candidates, key=lambda candidate: (-candidate.similarity, candidate.summary_record_id))
     matches: list[PrecedentMatch] = []
     for rank, candidate in enumerate(ordered[: policy.candidate_limit], start=1):

--- a/src/lumina/decision_precedent/service.py
+++ b/src/lumina/decision_precedent/service.py
@@ -1,0 +1,76 @@
+"""Scope-safe institutional retrieval bridge for decision precedent evaluation."""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from lumina.decision_precedent.policy import DecisionPrecedentPolicy
+from lumina.decision_precedent.scorer import DecisionConfidenceScore, PrecedentCandidate, score_decision_precedent
+from lumina.retrieval.contracts import RetrievalFilter
+from lumina.retrieval.institutional import InstitutionalMemoryIndexer
+
+
+def _confidence_from_cosine(score: float) -> float:
+    """Map cosine similarity from $[-1, 1]$ to confidence $[0, 1]$."""
+    return max(0.0, min(1.0, (score + 1.0) / 2.0))
+
+
+def _parse_created_utc(value: str | None) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo is not None else None
+
+
+def _precedent_candidates(results: object) -> list[PrecedentCandidate]:
+    """Keep only timestamped ThreadSummaryRecords and deduplicate by record ID."""
+    candidates: dict[str, PrecedentCandidate] = {}
+    for result in results:
+        chunk = result.chunk
+        created_utc = _parse_created_utc(chunk.created_utc)
+        if not chunk.thread_id or not chunk.record_id or created_utc is None:
+            continue
+        candidate = PrecedentCandidate(
+            summary_record_id=chunk.record_id,
+            thread_id=chunk.thread_id,
+            similarity=_confidence_from_cosine(result.score),
+            created_utc=created_utc,
+        )
+        current = candidates.get(candidate.summary_record_id)
+        if current is None or candidate.similarity > current.similarity:
+            candidates[candidate.summary_record_id] = candidate
+    return list(candidates.values())
+
+
+def evaluate_decision_precedent(
+    query: str,
+    *,
+    indexer: InstitutionalMemoryIndexer,
+    policy: DecisionPrecedentPolicy,
+    actor_id: str,
+    risk_class: str,
+    evaluated_utc: datetime | None = None,
+    record_id: str | None = None,
+) -> DecisionConfidenceScore:
+    """Return deterministic confidence from same-site summaries without retaining query text."""
+    if not isinstance(query, str) or not query.strip():
+        raise ValueError("decision precedent evaluation requires a non-empty query")
+    results = indexer.search(
+        query,
+        RetrievalFilter(
+            organization_id=policy.organization_id,
+            site_id=policy.site_id,
+            institutional_only=True,
+        ),
+        k=policy.candidate_limit,
+    )
+    return score_decision_precedent(
+        _precedent_candidates(results),
+        policy,
+        actor_id=actor_id,
+        risk_class=risk_class,
+        evaluated_utc=evaluated_utc or datetime.now(UTC),
+        record_id=record_id,
+    )

--- a/src/lumina/decision_precedent/service.py
+++ b/src/lumina/decision_precedent/service.py
@@ -29,6 +29,8 @@ def _precedent_candidates(results: object) -> list[PrecedentCandidate]:
     candidates: dict[str, PrecedentCandidate] = {}
     for result in results:
         chunk = result.chunk
+        if chunk.record_type != "ThreadSummaryRecord":
+            continue
         created_utc = _parse_created_utc(chunk.created_utc)
         if not chunk.thread_id or not chunk.record_id or created_utc is None:
             continue

--- a/src/lumina/retrieval/embedder.py
+++ b/src/lumina/retrieval/embedder.py
@@ -46,6 +46,7 @@ class DocChunk:
     external_record_type: str | None = field(default=None, repr=False)
     external_record_id: str | None = field(default=None, repr=False)
     module_key: str | None = field(default=None, repr=False)
+    created_utc: str | None = field(default=None, repr=False)
 
     @staticmethod
     def compute_hash(text: str) -> str:

--- a/src/lumina/retrieval/embedder.py
+++ b/src/lumina/retrieval/embedder.py
@@ -40,6 +40,7 @@ class DocChunk:
     site_id: str | None = field(default=None, repr=False)
     actor_id: str | None = field(default=None, repr=False)
     device_id: str | None = field(default=None, repr=False)
+    record_type: str | None = field(default=None, repr=False)
     record_id: str | None = field(default=None, repr=False)
     thread_id: str | None = field(default=None, repr=False)
     provider: str | None = field(default=None, repr=False)

--- a/src/lumina/retrieval/institutional.py
+++ b/src/lumina/retrieval/institutional.py
@@ -42,6 +42,7 @@ def _metadata(record: dict[str, Any]) -> dict[str, str | None]:
         "external_record_type": reference.get("external_record_type"),
         "external_record_id": reference.get("external_record_id"),
         "module_key": record.get("module_key"),
+        "created_utc": record.get("created_utc"),
     }
 
 
@@ -89,6 +90,7 @@ def record_to_chunk(record: dict[str, Any]) -> DocChunk:
         external_record_type=metadata["external_record_type"],
         external_record_id=metadata["external_record_id"],
         module_key=metadata["module_key"],
+        created_utc=metadata["created_utc"],
     )
 
 

--- a/src/lumina/retrieval/institutional.py
+++ b/src/lumina/retrieval/institutional.py
@@ -84,6 +84,7 @@ def record_to_chunk(record: dict[str, Any]) -> DocChunk:
         site_id=site_id,
         actor_id=actor_id,
         device_id=record.get("device_id") if isinstance(record.get("device_id"), str) else None,
+        record_type=record_type,
         record_id=record_id,
         thread_id=thread_id.strip() if isinstance(thread_id, str) else None,
         provider=metadata["provider"],

--- a/src/lumina/retrieval/vector_store.py
+++ b/src/lumina/retrieval/vector_store.py
@@ -180,6 +180,7 @@ class VectorStore:
                 external_record_type=r.get("external_record_type"),
                 external_record_id=r.get("external_record_id"),
                 module_key=r.get("module_key"),
+                created_utc=r.get("created_utc"),
             )
             for r in raw
         ]

--- a/src/lumina/retrieval/vector_store.py
+++ b/src/lumina/retrieval/vector_store.py
@@ -174,6 +174,7 @@ class VectorStore:
                 site_id=r.get("site_id"),
                 actor_id=r.get("actor_id"),
                 device_id=r.get("device_id"),
+                record_type=r.get("record_type"),
                 record_id=r.get("record_id"),
                 thread_id=r.get("thread_id"),
                 provider=r.get("provider"),

--- a/src/lumina/thread_routing/policy.py
+++ b/src/lumina/thread_routing/policy.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from lumina.core.policy_validation import validate_policy_header
 from lumina.core.yaml_loader import load_yaml
 
 _POLICY_FIELDS = frozenset({
@@ -128,12 +129,7 @@ def resolve_thread_routing_policy(
     """Resolve site, organization, then default policy for authenticated scope."""
     organization_id = _require_scope(organization_id, "organization_id")
     site_id = _require_scope(site_id, "site_id")
-    unknown = set(config) - {"schema_version", "policy_version", "defaults", "organizations"}
-    if unknown:
-        names = ", ".join(sorted(unknown))
-        raise ValueError(f"thread routing policy has unknown top-level fields: {names}")
-    if config.get("schema_version") != "1.0.0":
-        raise ValueError("unsupported thread routing policy schema_version")
+    config = validate_policy_header(config, policy_name="thread routing")
     policy_version = config.get("policy_version")
     defaults = _as_mapping(config.get("defaults"), "defaults")
     resolved = _merge_policy({}, defaults, "defaults")

--- a/src/lumina/thread_routing/summaries.py
+++ b/src/lumina/thread_routing/summaries.py
@@ -87,6 +87,7 @@ def record_thread_recap(
         "organization_id": policy.organization_id,
         "site_id": policy.site_id,
         "actor_id": actor_id,
+        "created_utc": updated_utc,
         "thread_id": thread_id,
         "summary": summary,
         "domain_id": domain_id or "",

--- a/standards/business-escalation-packet-schema-v1.json
+++ b/standards/business-escalation-packet-schema-v1.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://projectlumina.org/standards/business-escalation-packet-schema-v1.json",
+  "schema_version": "1.0.0",
+  "last_updated": "2026-07-20",
+  "title": "Business Escalation Packet Schema",
+  "description": "Transcript-free, scope-bound approval request created by a mandatory decision precedent escalation.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "packet_id", "organization_id", "site_id", "actor_id", "confidence_record_id",
+    "policy_version", "risk_class", "tier", "target_role", "status", "created_utc"
+  ],
+  "properties": {
+    "packet_id": {"type": "string", "minLength": 1},
+    "organization_id": {"type": "string", "minLength": 1},
+    "site_id": {"type": "string", "minLength": 1},
+    "actor_id": {"type": "string", "minLength": 1},
+    "confidence_record_id": {"type": "string", "minLength": 1},
+    "policy_version": {"type": "integer", "minimum": 1},
+    "risk_class": {"type": "string", "minLength": 1},
+    "tier": {"const": "mandatory_escalation"},
+    "target_role": {"type": "string", "minLength": 1},
+    "status": {"const": "pending"},
+    "precedent_summary_record_ids": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+    "created_utc": {"type": "string", "format": "date-time"}
+  }
+}

--- a/standards/decision-confidence-score-schema-v1.json
+++ b/standards/decision-confidence-score-schema-v1.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://projectlumina.org/standards/decision-confidence-score-schema-v1.json",
+  "schema_version": "1.0.0",
+  "last_updated": "2026-07-20",
+  "title": "Decision Confidence Score Schema",
+  "description": "Deterministic, transcript-free confidence evidence for a scoped decision precedent evaluation.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "record_id", "organization_id", "site_id", "actor_id", "policy_version",
+    "risk_class", "similarity_score", "recency_penalty", "missing_precedent_penalty",
+    "final_score", "tier", "rationale_codes", "precedent_matches", "created_utc"
+  ],
+  "properties": {
+    "record_id": {"type": "string", "minLength": 1},
+    "organization_id": {"type": "string", "minLength": 1},
+    "site_id": {"type": "string", "minLength": 1},
+    "actor_id": {"type": "string", "minLength": 1},
+    "policy_version": {"type": "integer", "minimum": 1},
+    "risk_class": {"type": "string", "minLength": 1},
+    "similarity_score": {"type": "number", "minimum": 0, "maximum": 1},
+    "recency_penalty": {"type": "number", "minimum": 0, "maximum": 1},
+    "missing_precedent_penalty": {"type": "number", "minimum": 0, "maximum": 1},
+    "final_score": {"type": "number", "minimum": 0, "maximum": 1},
+    "tier": {"type": "string", "enum": ["suggest_only", "require_confirmation", "mandatory_escalation"]},
+    "rationale_codes": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+    "precedent_matches": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "record_id", "organization_id", "site_id", "actor_id", "summary_record_id",
+          "thread_id", "similarity", "created_utc", "recency_band", "rank"
+        ],
+        "properties": {
+          "record_id": {"type": "string", "minLength": 1},
+          "organization_id": {"type": "string", "minLength": 1},
+          "site_id": {"type": "string", "minLength": 1},
+          "actor_id": {"type": "string", "minLength": 1},
+          "summary_record_id": {"type": "string", "minLength": 1},
+          "thread_id": {"type": "string", "minLength": 1},
+          "similarity": {"type": "number", "minimum": 0, "maximum": 1},
+          "created_utc": {"type": "string", "format": "date-time"},
+          "recency_band": {"type": "string", "enum": ["current", "stale"]},
+          "rank": {"type": "integer", "minimum": 1}
+        }
+      }
+    },
+    "created_utc": {"type": "string", "format": "date-time"}
+  }
+}

--- a/standards/decision-precedent-policy-schema-v1.json
+++ b/standards/decision-precedent-policy-schema-v1.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://projectlumina.org/standards/decision-precedent-policy-schema-v1.json",
+  "schema_version": "1.0.0",
+  "last_updated": "2026-07-20",
+  "title": "Decision Precedent Policy Schema",
+  "description": "Business Ops configuration for deterministic, scoped decision precedent evaluation.",
+  "type": "object",
+  "required": ["schema_version", "policy_version", "defaults", "organizations"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {"const": "1.0.0"},
+    "policy_version": {"type": "integer", "minimum": 1},
+    "defaults": {"$ref": "#/$defs/policy"},
+    "organizations": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/override"
+      }
+    }
+  },
+  "$defs": {
+    "policy": {
+      "type": "object",
+      "required": [
+        "candidate_limit",
+        "suggest_threshold",
+        "confirmation_threshold",
+        "stale_after_days",
+        "stale_penalty",
+        "missing_precedent_penalty",
+        "high_risk_classes",
+        "confirmation_risk_classes"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "candidate_limit": {"type": "integer", "minimum": 1},
+        "suggest_threshold": {"type": "number", "minimum": 0, "maximum": 1},
+        "confirmation_threshold": {"type": "number", "minimum": 0, "maximum": 1},
+        "stale_after_days": {"type": "integer", "minimum": 1},
+        "stale_penalty": {"type": "number", "minimum": 0, "maximum": 1},
+        "missing_precedent_penalty": {"type": "number", "minimum": 0, "maximum": 1},
+        "high_risk_classes": {"$ref": "#/$defs/riskClasses"},
+        "confirmation_risk_classes": {"$ref": "#/$defs/riskClasses"}
+      }
+    },
+    "override": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "candidate_limit": {"type": "integer", "minimum": 1},
+        "suggest_threshold": {"type": "number", "minimum": 0, "maximum": 1},
+        "confirmation_threshold": {"type": "number", "minimum": 0, "maximum": 1},
+        "stale_after_days": {"type": "integer", "minimum": 1},
+        "stale_penalty": {"type": "number", "minimum": 0, "maximum": 1},
+        "missing_precedent_penalty": {"type": "number", "minimum": 0, "maximum": 1},
+        "high_risk_classes": {"$ref": "#/$defs/riskClasses"},
+        "confirmation_risk_classes": {"$ref": "#/$defs/riskClasses"},
+        "sites": {
+          "type": "object",
+          "additionalProperties": {"$ref": "#/$defs/override"}
+        }
+      }
+    },
+    "riskClasses": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1},
+      "uniqueItems": true
+    }
+  }
+}

--- a/standards/precedent-match-schema-v1.json
+++ b/standards/precedent-match-schema-v1.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://projectlumina.org/standards/precedent-match-schema-v1.json",
+  "schema_version": "1.0.0",
+  "last_updated": "2026-07-20",
+  "title": "Precedent Match Schema",
+  "description": "Transcript-free, scope-bound institutional evidence selected for a decision precedent evaluation.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "record_id", "organization_id", "site_id", "actor_id", "summary_record_id",
+    "thread_id", "similarity", "created_utc", "recency_band", "rank"
+  ],
+  "properties": {
+    "record_id": {"type": "string", "minLength": 1},
+    "organization_id": {"type": "string", "minLength": 1},
+    "site_id": {"type": "string", "minLength": 1},
+    "actor_id": {"type": "string", "minLength": 1},
+    "summary_record_id": {"type": "string", "minLength": 1},
+    "thread_id": {"type": "string", "minLength": 1},
+    "similarity": {"type": "number", "minimum": 0, "maximum": 1},
+    "created_utc": {"type": "string", "format": "date-time"},
+    "recency_band": {"type": "string", "enum": ["current", "stale"]},
+    "rank": {"type": "integer", "minimum": 1}
+  }
+}

--- a/standards/thread-summary-record-schema-v1.json
+++ b/standards/thread-summary-record-schema-v1.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://projectlumina.org/memory/thread-summary-record-schema-v1.json",
-  "schema_version": "1.0.0",
-  "last_updated": "2026-07-15",
+  "schema_version": "1.0.1",
+  "last_updated": "2026-07-20",
   "title": "Thread Summary Record Schema V1",
   "description": "A concise, pseudonymous summary of a scoped operational thread without raw transcript persistence.",
   "type": "object",
@@ -17,6 +17,7 @@
     "device_id": { "type": ["string", "null"], "minLength": 1 },
     "thread_id": { "type": "string", "minLength": 1 },
     "summary": { "type": "string", "minLength": 1, "maxLength": 4096 },
+    "domain_id": { "type": ["string", "null"] },
     "topics": { "type": "array", "items": { "type": "string", "minLength": 1 } },
     "status": { "type": "string", "enum": ["open", "resolved", "escalated", "archived"] },
     "created_utc": { "type": "string", "format": "date-time" },

--- a/tests/test_decision_precedent_api.py
+++ b/tests/test_decision_precedent_api.py
@@ -1,0 +1,137 @@
+"""Integration tests for the authenticated Slice 29 decision precedent API."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+from lumina.auth import auth
+from lumina.persistence.adapter import NullPersistenceAdapter
+from lumina.retrieval.embedder import EMBEDDING_DIM
+from lumina.retrieval.institutional import InstitutionalMemoryIndexer
+from lumina.retrieval.vector_store import VectorStore
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class _RecordingPersistence(NullPersistenceAdapter):
+    def __init__(self) -> None:
+        super().__init__()
+        self.records: list[dict] = []
+
+    def append_log_record(self, session_id, record, ledger_path=None) -> None:
+        self.records.append(dict(record))
+        super().append_log_record(session_id, record, ledger_path)
+
+
+class _FakeEmbedder:
+    def embed_chunks(self, chunks):
+        return np.asarray([self.embed_query(chunk.text) for chunk in chunks], dtype=np.float32)
+
+    def embed_query(self, query):
+        vector = np.zeros(EMBEDDING_DIM, dtype=np.float32)
+        vector[0 if "brake" in query.lower() else 1] = 1.0
+        return vector
+
+
+def _load_api_module():
+    module_path = _REPO_ROOT / "src" / "lumina" / "api" / "server.py"
+    spec = importlib.util.spec_from_file_location("lumina.api.server", str(module_path))
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Could not load lumina-api-server module")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["lumina.api.server"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _summary(record_id: str, *, site_id: str = "site-1") -> dict:
+    return {
+        "record_type": "ThreadSummaryRecord", "record_id": record_id,
+        "organization_id": "org-a", "site_id": site_id, "actor_id": "actor-a",
+        "thread_id": f"thread-{record_id}", "summary": "Brake inspection work order.",
+        "created_utc": "2026-07-20T12:00:00Z",
+    }
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setenv("LUMINA_RUNTIME_CONFIG_PATH", "model-packs/education/cfg/runtime-config.yaml")
+    monkeypatch.delenv("LUMINA_DOMAIN_REGISTRY_PATH", raising=False)
+    module = _load_api_module()
+    persistence = _RecordingPersistence()
+    module.PERSISTENCE = persistence
+    monkeypatch.setattr(auth, "JWT_SECRET", "test-secret")
+    indexer = InstitutionalMemoryIndexer(VectorStore(tmp_path / "memory"), _FakeEmbedder())
+    indexer.ingest([_summary("same-site"), _summary("other-site", site_id="site-2")])
+    import lumina.api.routes.decision_precedent as route_module
+    monkeypatch.setattr(route_module, "_get_institutional_indexer", lambda: indexer)
+    route_module._pending_confirmations.clear()
+    route_module._consumed_confirmation_ids.clear()
+    return TestClient(module.app), persistence
+
+
+def _token(
+    *, actor_id: str = "actor-a", organization_id: str | None = "org-a", site_id: str | None = "site-1"
+) -> str:
+    return auth.create_scoped_jwt(
+        user_id=actor_id, role="user", organization_id=organization_id, site_id=site_id
+    )
+
+
+@pytest.mark.integration
+def test_preflight_uses_same_site_evidence_without_retaining_message(client) -> None:
+    test_client, persistence = client
+    response = test_client.post("/api/decision-precedent/preflight", headers={"Authorization": f"Bearer {_token()}"}, json={"message": "brake update", "risk_class": "routine", "session_id": "session-1"})
+
+    assert response.status_code == 200
+    assert response.json()["tier"] == "suggest_only"
+    trace = persistence.records[0]
+    evidence = trace["evidence_summary"]["decision_confidence_score"]
+    assert evidence["precedent_matches"][0]["summary_record_id"] == "same-site"
+    assert "message" not in evidence
+    assert "brake update" not in str(evidence)
+
+
+@pytest.mark.integration
+def test_high_risk_preflight_creates_pending_standard_escalation(client) -> None:
+    test_client, persistence = client
+    response = test_client.post("/api/decision-precedent/preflight", headers={"Authorization": f"Bearer {_token()}"}, json={"message": "brake update", "risk_class": "financial"})
+
+    assert response.status_code == 200
+    assert response.json()["tier"] == "mandatory_escalation"
+    assert response.json()["escalation_record_id"]
+    escalation = persistence.records[1]
+    assert escalation["record_type"] == "EscalationRecord"
+    assert escalation["status"] == "pending"
+    assert "message" not in escalation["evidence_summary"]
+
+
+@pytest.mark.integration
+def test_confirmation_is_scoped_and_replay_protected(client) -> None:
+    test_client, persistence = client
+    preflight = test_client.post("/api/decision-precedent/preflight", headers={"Authorization": f"Bearer {_token()}"}, json={"message": "brake update", "risk_class": "operational"})
+    assert preflight.status_code == 200
+    confidence_record_id = preflight.json()["confidence_record_id"]
+    assert preflight.json()["confirmation_required"] is True
+
+    confirmed = test_client.post(f"/api/decision-precedent/{confidence_record_id}/confirm", headers={"Authorization": f"Bearer {_token()}"})
+    assert confirmed.status_code == 200
+    assert confirmed.json()["tier"] == "require_confirmation"
+    assert persistence.records[-1]["decision"] == "decision_precedent_confirmed"
+
+    replay = test_client.post(f"/api/decision-precedent/{confidence_record_id}/confirm", headers={"Authorization": f"Bearer {_token()}"})
+    assert replay.status_code == 409
+
+
+@pytest.mark.integration
+def test_preflight_requires_active_operating_context(client) -> None:
+    test_client, persistence = client
+    response = test_client.post("/api/decision-precedent/preflight", headers={"Authorization": f"Bearer {_token(organization_id=None, site_id=None)}"}, json={"message": "brake update", "risk_class": "routine"})
+
+    assert response.status_code == 403
+    assert persistence.records == []

--- a/tests/test_decision_precedent_api.py
+++ b/tests/test_decision_precedent_api.py
@@ -69,7 +69,7 @@ def client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     indexer = InstitutionalMemoryIndexer(VectorStore(tmp_path / "memory"), _FakeEmbedder())
     indexer.ingest([_summary("same-site"), _summary("other-site", site_id="site-2")])
     import lumina.api.routes.decision_precedent as route_module
-    monkeypatch.setattr(route_module, "_get_institutional_indexer", lambda: indexer)
+    monkeypatch.setattr(route_module, "get_institutional_indexer", lambda: indexer)
     route_module._pending_confirmations.clear()
     route_module._consumed_confirmation_ids.clear()
     return TestClient(module.app), persistence

--- a/tests/test_decision_precedent_policy.py
+++ b/tests/test_decision_precedent_policy.py
@@ -1,0 +1,117 @@
+"""Tests for Slice 29 Business Ops decision-precedent policy resolution."""
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from lumina.decision_precedent.policy import (
+    load_decision_precedent_policy,
+    resolve_decision_precedent_policy,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+POLICY_PATH = REPO_ROOT / "model-packs" / "business-ops" / "cfg" / "decision-precedent-policy.yaml"
+SCHEMA_PATH = REPO_ROOT / "standards" / "decision-precedent-policy-schema-v1.json"
+
+
+def _config() -> dict:
+    return {
+        "schema_version": "1.0.0",
+        "policy_version": 3,
+        "defaults": {
+            "candidate_limit": 5,
+            "suggest_threshold": 0.85,
+            "confirmation_threshold": 0.65,
+            "stale_after_days": 60,
+            "stale_penalty": 0.20,
+            "missing_precedent_penalty": 1.0,
+            "high_risk_classes": ["financial"],
+            "confirmation_risk_classes": ["operational"],
+        },
+        "organizations": {},
+    }
+
+
+@pytest.mark.unit
+def test_business_ops_policy_file_matches_schema() -> None:
+    import yaml
+
+    config = yaml.safe_load(POLICY_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(config, json.loads(SCHEMA_PATH.read_text(encoding="utf-8")))
+
+
+@pytest.mark.unit
+def test_policy_resolves_default_organization_and_site_precedence() -> None:
+    config = _config()
+    config["organizations"] = {
+        "org-a": {
+            "suggest_threshold": 0.90,
+            "stale_after_days": 30,
+            "sites": {"site-a": {"confirmation_threshold": 0.75, "candidate_limit": 3}},
+        }
+    }
+
+    policy = resolve_decision_precedent_policy(config, organization_id="org-a", site_id="site-a")
+
+    assert policy.suggest_threshold == 0.90
+    assert policy.confirmation_threshold == 0.75
+    assert policy.stale_after_days == 30
+    assert policy.candidate_limit == 3
+    assert policy.organization_id == "org-a"
+    assert policy.site_id == "site-a"
+
+
+@pytest.mark.unit
+def test_policy_does_not_leak_another_organization_override() -> None:
+    config = _config()
+    config["organizations"] = {"org-a": {"suggest_threshold": 0.99}}
+
+    policy = resolve_decision_precedent_policy(config, organization_id="org-b", site_id="site-a")
+
+    assert policy.suggest_threshold == 0.85
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("organization_id,site_id", [("", "site-a"), ("org-a", "")])
+def test_policy_requires_authenticated_scope(organization_id: str, site_id: str) -> None:
+    with pytest.raises(ValueError, match="requires"):
+        resolve_decision_precedent_policy(_config(), organization_id=organization_id, site_id=site_id)
+
+
+@pytest.mark.unit
+def test_policy_rejects_reversed_thresholds() -> None:
+    config = _config()
+    config["defaults"]["confirmation_threshold"] = 0.86
+
+    with pytest.raises(ValueError, match="cannot exceed"):
+        resolve_decision_precedent_policy(config, organization_id="org-a", site_id="site-a")
+
+
+@pytest.mark.unit
+def test_policy_rejects_overlapping_risk_classes() -> None:
+    config = _config()
+    config["defaults"]["confirmation_risk_classes"] = ["financial"]
+
+    with pytest.raises(ValueError, match="cannot overlap"):
+        resolve_decision_precedent_policy(config, organization_id="org-a", site_id="site-a")
+
+
+@pytest.mark.unit
+def test_policy_rejects_unknown_override_fields() -> None:
+    config = deepcopy(_config())
+    config["organizations"] = {"org-a": {"skip_audit": True}}
+
+    with pytest.raises(ValueError, match="unknown fields"):
+        resolve_decision_precedent_policy(config, organization_id="org-a", site_id="site-a")
+
+
+@pytest.mark.unit
+def test_policy_file_loads_through_core_yaml_loader() -> None:
+    policy = load_decision_precedent_policy(POLICY_PATH, organization_id="org-a", site_id="site-a")
+
+    assert policy.policy_version == 1
+    assert policy.high_risk_classes == ("financial", "safety", "legal")

--- a/tests/test_decision_precedent_policy.py
+++ b/tests/test_decision_precedent_policy.py
@@ -110,6 +110,15 @@ def test_policy_rejects_unknown_override_fields() -> None:
 
 
 @pytest.mark.unit
+def test_policy_rejects_unknown_top_level_fields() -> None:
+    config = _config()
+    config["skip_audit"] = True
+
+    with pytest.raises(ValueError, match="unknown top-level"):
+        resolve_decision_precedent_policy(config, organization_id="org-a", site_id="site-a")
+
+
+@pytest.mark.unit
 def test_policy_file_loads_through_core_yaml_loader() -> None:
     policy = load_decision_precedent_policy(POLICY_PATH, organization_id="org-a", site_id="site-a")
 

--- a/tests/test_decision_precedent_schemas.py
+++ b/tests/test_decision_precedent_schemas.py
@@ -1,0 +1,78 @@
+"""Validation tests for Slice 29 policy and transcript-free evidence contracts."""
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from datetime import UTC, datetime
+from pathlib import Path
+
+import jsonschema
+import pytest
+import yaml
+
+from lumina.decision_precedent.policy import resolve_decision_precedent_policy
+from lumina.decision_precedent.scorer import PrecedentCandidate, score_decision_precedent
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+STANDARDS = REPO_ROOT / "standards"
+POLICY_PATH = REPO_ROOT / "model-packs" / "business-ops" / "cfg" / "decision-precedent-policy.yaml"
+
+
+def _schema(name: str) -> dict:
+    return json.loads((STANDARDS / name).read_text(encoding="utf-8"))
+
+
+def _score_record() -> dict:
+    config = yaml.safe_load(POLICY_PATH.read_text(encoding="utf-8"))
+    policy = resolve_decision_precedent_policy(config, organization_id="org-a", site_id="site-a")
+    return score_decision_precedent(
+        [PrecedentCandidate("summary-a", "thread-a", 0.91, datetime(2026, 7, 20, tzinfo=UTC))],
+        policy,
+        actor_id="actor-a",
+        risk_class="routine",
+        evaluated_utc=datetime(2026, 7, 20, tzinfo=UTC),
+        record_id="confidence-a",
+    ).as_record(created_utc=datetime(2026, 7, 20, tzinfo=UTC))
+
+
+@pytest.mark.unit
+def test_policy_schema_accepts_site_override() -> None:
+    config = yaml.safe_load(POLICY_PATH.read_text(encoding="utf-8"))
+    config["organizations"] = {"org-a": {"sites": {"site-a": {"candidate_limit": 3}}}}
+
+    jsonschema.validate(config, _schema("decision-precedent-policy-schema-v1.json"))
+
+
+@pytest.mark.unit
+def test_confidence_score_and_match_records_validate() -> None:
+    record = _score_record()
+
+    jsonschema.validate(record, _schema("decision-confidence-score-schema-v1.json"), format_checker=jsonschema.FormatChecker())
+    jsonschema.validate(record["precedent_matches"][0], _schema("precedent-match-schema-v1.json"), format_checker=jsonschema.FormatChecker())
+
+
+@pytest.mark.unit
+def test_confidence_contract_rejects_raw_message_field() -> None:
+    record = _score_record()
+    record["message"] = "raw transcript content"
+
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(record, _schema("decision-confidence-score-schema-v1.json"))
+
+
+@pytest.mark.unit
+def test_escalation_packet_contract_rejects_provider_mutation_data() -> None:
+    packet = {
+        "packet_id": "packet-a", "organization_id": "org-a", "site_id": "site-a",
+        "actor_id": "actor-a", "confidence_record_id": "confidence-a", "policy_version": 1,
+        "risk_class": "financial", "tier": "mandatory_escalation",
+        "target_role": "business-ops:owner-manager", "status": "pending",
+        "precedent_summary_record_ids": ["summary-a"], "created_utc": "2026-07-20T00:00:00Z",
+    }
+    schema = _schema("business-escalation-packet-schema-v1.json")
+    jsonschema.validate(packet, schema, format_checker=jsonschema.FormatChecker())
+    unsafe_packet = deepcopy(packet)
+    unsafe_packet["provider_mutation"] = {"operation": "create_work_order"}
+
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(unsafe_packet, schema)

--- a/tests/test_decision_precedent_scorer.py
+++ b/tests/test_decision_precedent_scorer.py
@@ -1,0 +1,78 @@
+"""Tests for deterministic Slice 29 decision-precedent confidence scoring."""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from lumina.decision_precedent.policy import DecisionPrecedentPolicy
+from lumina.decision_precedent.scorer import PrecedentCandidate, score_decision_precedent
+
+NOW = datetime(2026, 7, 20, tzinfo=UTC)
+
+
+def _policy() -> DecisionPrecedentPolicy:
+    return DecisionPrecedentPolicy(
+        policy_version=1, candidate_limit=3, suggest_threshold=0.88,
+        confirmation_threshold=0.70, stale_after_days=90, stale_penalty=0.18,
+        missing_precedent_penalty=1.0, high_risk_classes=("financial",),
+        confirmation_risk_classes=("operational",), organization_id="org-a", site_id="site-a",
+    )
+
+
+def _candidate(score: float, *, age_days: int = 1, record_id: str = "summary-a") -> PrecedentCandidate:
+    return PrecedentCandidate(
+        summary_record_id=record_id, thread_id="thread-a", similarity=score,
+        created_utc=NOW - timedelta(days=age_days),
+    )
+
+
+@pytest.mark.unit
+def test_high_confidence_low_risk_precedent_is_suggest_only() -> None:
+    score = score_decision_precedent([_candidate(0.91)], _policy(), actor_id="actor-a", risk_class="routine", evaluated_utc=NOW, record_id="score-a")
+
+    assert score.final_score == 0.91
+    assert score.tier == "suggest_only"
+    assert score.rationale_codes == ("high_confidence_precedent",)
+
+
+@pytest.mark.unit
+def test_high_risk_overrides_high_similarity() -> None:
+    score = score_decision_precedent([_candidate(0.99)], _policy(), actor_id="actor-a", risk_class="financial", evaluated_utc=NOW)
+
+    assert score.tier == "mandatory_escalation"
+    assert "high_risk_class" in score.rationale_codes
+
+
+@pytest.mark.unit
+def test_missing_precedent_always_escalates() -> None:
+    score = score_decision_precedent([], _policy(), actor_id="actor-a", risk_class="routine", evaluated_utc=NOW)
+
+    assert score.final_score == 0.0
+    assert score.tier == "mandatory_escalation"
+    assert score.missing_precedent_penalty == 1.0
+
+
+@pytest.mark.unit
+def test_stale_precedent_applies_policy_penalty() -> None:
+    score = score_decision_precedent([_candidate(0.90, age_days=91)], _policy(), actor_id="actor-a", risk_class="routine", evaluated_utc=NOW)
+
+    assert score.final_score == 0.72
+    assert score.tier == "require_confirmation"
+    assert score.precedent_matches[0].recency_band == "stale"
+
+
+@pytest.mark.unit
+def test_equal_scores_have_stable_record_id_ordering() -> None:
+    score = score_decision_precedent([_candidate(0.80, record_id="summary-z"), _candidate(0.80, record_id="summary-a")], _policy(), actor_id="actor-a", risk_class="routine", evaluated_utc=NOW)
+
+    assert [match.summary_record_id for match in score.precedent_matches] == ["summary-a", "summary-z"]
+
+
+@pytest.mark.unit
+def test_score_record_is_transcript_free_and_schema_ready() -> None:
+    record = score_decision_precedent([_candidate(0.91)], _policy(), actor_id="actor-a", risk_class="routine", evaluated_utc=NOW, record_id="score-a").as_record(created_utc=NOW)
+
+    assert record["record_id"] == "score-a"
+    assert "summary" not in record
+    assert "message" not in record

--- a/tests/test_decision_precedent_service.py
+++ b/tests/test_decision_precedent_service.py
@@ -72,6 +72,22 @@ def test_missing_timestamp_is_not_eligible_precedent(tmp_path) -> None:
 
 
 @pytest.mark.unit
+def test_non_summary_institutional_records_are_not_eligible_precedent(tmp_path) -> None:
+    indexer = InstitutionalMemoryIndexer(VectorStore(tmp_path / "memory"), _FakeEmbedder())
+    non_summary = _summary("non-summary")
+    non_summary["record_type"] = "DecisionConfidenceScore"
+    indexer.ingest([non_summary])
+
+    score = evaluate_decision_precedent(
+        "brake update", indexer=indexer, policy=_policy(), actor_id="actor-a", risk_class="routine",
+        evaluated_utc=datetime(2026, 7, 20, tzinfo=UTC), record_id="score-a",
+    )
+
+    assert score.tier == "mandatory_escalation"
+    assert score.precedent_matches == ()
+
+
+@pytest.mark.unit
 def test_persisted_store_retains_summary_timestamp(tmp_path) -> None:
     store = VectorStore(tmp_path / "memory")
     indexer = InstitutionalMemoryIndexer(store, _FakeEmbedder())

--- a/tests/test_decision_precedent_service.py
+++ b/tests/test_decision_precedent_service.py
@@ -1,0 +1,86 @@
+"""Tests for scope-safe Slice 29 institutional precedent retrieval."""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import numpy as np
+import pytest
+
+from lumina.decision_precedent.policy import DecisionPrecedentPolicy
+from lumina.decision_precedent.service import evaluate_decision_precedent
+from lumina.retrieval.embedder import EMBEDDING_DIM
+from lumina.retrieval.institutional import InstitutionalMemoryIndexer
+from lumina.retrieval.vector_store import VectorStore
+
+
+class _FakeEmbedder:
+    def embed_chunks(self, chunks):
+        return np.asarray([self.embed_query(chunk.text) for chunk in chunks], dtype=np.float32)
+
+    def embed_query(self, query):
+        vector = np.zeros(EMBEDDING_DIM, dtype=np.float32)
+        vector[0 if "brake" in query.lower() else 1] = 1.0
+        return vector
+
+
+def _policy() -> DecisionPrecedentPolicy:
+    return DecisionPrecedentPolicy(
+        policy_version=1, candidate_limit=5, suggest_threshold=0.88, confirmation_threshold=0.70,
+        stale_after_days=90, stale_penalty=0.18, missing_precedent_penalty=1.0,
+        high_risk_classes=("financial",), confirmation_risk_classes=("operational",),
+        organization_id="org-a", site_id="site-a",
+    )
+
+
+def _summary(record_id: str, *, organization_id: str = "org-a", site_id: str = "site-a", created_utc: str = "2026-07-19T12:00:00Z") -> dict:
+    return {
+        "record_type": "ThreadSummaryRecord", "record_id": record_id,
+        "organization_id": organization_id, "site_id": site_id, "actor_id": "actor-a",
+        "thread_id": f"thread-{record_id}", "summary": "Brake inspection work order.",
+        "created_utc": created_utc,
+    }
+
+
+@pytest.mark.unit
+def test_evaluation_uses_only_same_site_timestamped_summaries(tmp_path) -> None:
+    indexer = InstitutionalMemoryIndexer(VectorStore(tmp_path / "memory"), _FakeEmbedder())
+    indexer.ingest([_summary("same-site"), _summary("other-site", site_id="site-b")])
+
+    score = evaluate_decision_precedent(
+        "brake update", indexer=indexer, policy=_policy(), actor_id="actor-a", risk_class="routine",
+        evaluated_utc=datetime(2026, 7, 20, tzinfo=UTC), record_id="score-a",
+    )
+
+    assert score.tier == "suggest_only"
+    assert [match.summary_record_id for match in score.precedent_matches] == ["same-site"]
+
+
+@pytest.mark.unit
+def test_missing_timestamp_is_not_eligible_precedent(tmp_path) -> None:
+    indexer = InstitutionalMemoryIndexer(VectorStore(tmp_path / "memory"), _FakeEmbedder())
+    record = _summary("untimestamped")
+    record.pop("created_utc")
+    indexer.ingest([record])
+
+    score = evaluate_decision_precedent(
+        "brake update", indexer=indexer, policy=_policy(), actor_id="actor-a", risk_class="routine",
+        evaluated_utc=datetime(2026, 7, 20, tzinfo=UTC), record_id="score-a",
+    )
+
+    assert score.tier == "mandatory_escalation"
+    assert score.precedent_matches == ()
+
+
+@pytest.mark.unit
+def test_persisted_store_retains_summary_timestamp(tmp_path) -> None:
+    store = VectorStore(tmp_path / "memory")
+    indexer = InstitutionalMemoryIndexer(store, _FakeEmbedder())
+    indexer.ingest([_summary("persisted")])
+    reloaded = InstitutionalMemoryIndexer(VectorStore(tmp_path / "memory"), _FakeEmbedder())
+
+    score = evaluate_decision_precedent(
+        "brake update", indexer=reloaded, policy=_policy(), actor_id="actor-a", risk_class="routine",
+        evaluated_utc=datetime(2026, 7, 20, tzinfo=UTC), record_id="score-a",
+    )
+
+    assert score.precedent_matches[0].created_utc == datetime(2026, 7, 19, 12, tzinfo=UTC)

--- a/tests/test_thread_routing_api.py
+++ b/tests/test_thread_routing_api.py
@@ -93,7 +93,7 @@ def client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
         actor_id="actor-a",
     )
     import lumina.api.routes.thread_routing as route_module
-    monkeypatch.setattr(route_module, "_get_institutional_indexer", lambda: indexer)
+    monkeypatch.setattr(route_module, "get_institutional_indexer", lambda: indexer)
     route_module._pending_decisions.clear()
     route_module._consumed_decision_ids.clear()
     return TestClient(mod.app), persistence

--- a/tests/test_thread_routing_summaries.py
+++ b/tests/test_thread_routing_summaries.py
@@ -12,6 +12,7 @@ from lumina.thread_routing.summaries import record_thread_recap
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCHEMA_PATH = REPO_ROOT / "standards" / "thread-summary-state-schema-v1.json"
+SUMMARY_RECORD_SCHEMA_PATH = REPO_ROOT / "standards" / "thread-summary-record-schema-v1.json"
 
 
 class _RecordingIndexer:
@@ -59,6 +60,8 @@ def test_recap_indexes_first_turn_and_uses_schema_valid_transcript_free_state() 
     schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
     jsonschema.validate(state, schema, format_checker=jsonschema.FormatChecker())
     assert len(indexer.records) == 1
+    summary_schema = json.loads(SUMMARY_RECORD_SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(indexer.records[0], summary_schema, format_checker=jsonschema.FormatChecker())
     serialized = json.dumps({"state": state, "record": indexer.records[0]}).lower()
     assert message.lower() not in serialized
     assert "transcript" not in serialized


### PR DESCRIPTION
## Summary

Implements the Slice 29 backend foundation for deterministic, scope-safe decision precedent evaluation.

- Adds Business Ops policy resolution with default, organization, and site precedence.
- Retrieves only same-organization/site institutional thread summaries and scores confidence deterministically from similarity, recency, and policy-declared risk.
- Adds transcript-free contracts for precedent matches, confidence scores, escalation packets, and policy configuration.
- Adds authenticated preflight and confirmation APIs. Mandatory outcomes append a standard pending `EscalationRecord`; confirmation records intent only and cannot execute a business action.
- Preserves `created_utc` through institutional indexing and vector-store reloads so recency penalties remain deterministic.

## Authority and Scope Boundaries

- Active JWT organization/site context is required for all endpoints.
- Cross-site and untimestamped summaries are ineligible precedent evidence.
- High-risk and missing-precedent cases always escalate.
- No connector routing, provider-specific integration, approval resolution, or business mutation is included.
- Audit and escalation evidence contain IDs, scores, policy metadata, and rationale codes only; no raw messages or transcripts.

## Validation

- Focused Slice 29 plus adjacent Slice 28 regression: `1,247 passed, 1 warning`
- Full Python suite: `5,421 passed, 2 skipped, 1 warning`
- Manifest integrity: `343 OK`, `1` existing pending Slice 02 artifact, `0 mismatch`
- `git diff --check`: passed

## Non-goals

Compact frontend transport remains a follow-up Slice 29 step. Slice 30+ provider-neutral business contracts, connectors, and business mutations are intentionally out of scope.