### PR TITLE
Slice 31 PR1: routing contracts and deterministic resolver core

### DIFF
--- a/docs/MANIFEST.yaml
+++ b/docs/MANIFEST.yaml
@@ -1157,7 +1157,7 @@ artifacts:
   doc_version: 1.0.0
   status: active
   last_updated: 2026-07-26
-  sha256: a0c05759523ecc3797866f607e76e0d9956142a737a71fd84f9d680b0b7f3672
+  sha256: a07bf0a9e08622dae5368f1e5836451051ad2b173a91ae6e1e93ddb6dbede096
 - path: standards/admin-command-schemas/approve-interpretation.json
   type: schema
   doc_version: 1.0.0

--- a/docs/MANIFEST.yaml
+++ b/docs/MANIFEST.yaml
@@ -1140,6 +1140,24 @@ artifacts:
   status: active
   last_updated: 2026-07-24
   sha256: 153a9fa7bd2dd230b4b4e1c3ca256e730cd575ddf892e31fe488caff74a208ef
+- path: standards/connector-registry-entry-schema-v1.json
+  type: schema
+  doc_version: 1.0.0
+  status: active
+  last_updated: 2026-07-26
+  sha256: 2fdaf70396a45781d1fd229d0db56cc61a9376b673702e178b58e72c376ef7c7
+- path: standards/capability-route-policy-schema-v1.json
+  type: schema
+  doc_version: 1.0.0
+  status: active
+  last_updated: 2026-07-26
+  sha256: b43b4f1a1d3f79afb97cb80f5a7cc2305c36aaad34cfd323fb10830423aa5bea
+- path: standards/connector-resolution-result-schema-v1.json
+  type: schema
+  doc_version: 1.0.0
+  status: active
+  last_updated: 2026-07-26
+  sha256: a0c05759523ecc3797866f607e76e0d9956142a737a71fd84f9d680b0b7f3672
 - path: standards/admin-command-schemas/approve-interpretation.json
   type: schema
   doc_version: 1.0.0

--- a/src/lumina/connector_routing/__init__.py
+++ b/src/lumina/connector_routing/__init__.py
@@ -1,0 +1,17 @@
+"""Deterministic connector routing for Business Ops."""
+
+from .router import (
+    CapabilityRoute,
+    CapabilityRoutePolicy,
+    ConnectorRegistryEntry,
+    ConnectorResolutionResult,
+    resolve_connector,
+)
+
+__all__ = [
+    "CapabilityRoute",
+    "CapabilityRoutePolicy",
+    "ConnectorRegistryEntry",
+    "ConnectorResolutionResult",
+    "resolve_connector",
+]

--- a/src/lumina/connector_routing/router.py
+++ b/src/lumina/connector_routing/router.py
@@ -1,0 +1,497 @@
+"""Pure, deterministic connector routing decisions for Slice 31."""
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Literal
+
+ActionClass = Literal[
+    "query",
+    "create_draft",
+    "update_draft",
+    "request_commit",
+    "request_cancel",
+    "sync_event",
+]
+ResolutionSource = Literal[
+    "operation_override",
+    "capability_route",
+    "site_primary",
+    "organization_default",
+    "no_route",
+]
+ResolutionStatus = Literal["resolved", "error"]
+ReasonCode = Literal[
+    "ok",
+    "missing_idempotency_key",
+    "override_not_found",
+    "override_ineligible",
+    "ambiguous_route",
+    "capability_route_not_found",
+    "site_primary_not_found",
+    "organization_default_not_found",
+    "unsupported_capability",
+    "unsupported_action",
+    "connector_unhealthy",
+    "no_eligible_connector",
+]
+HealthStatus = Literal["healthy", "degraded", "unhealthy"]
+
+_MUTATION_ACTIONS = frozenset({
+    "create_draft",
+    "update_draft",
+    "request_commit",
+    "request_cancel",
+    "sync_event",
+})
+
+
+@dataclass(frozen=True)
+class ConnectorRegistryEntry:
+    organization_id: str
+    site_id: str
+    connector_instance_id: str
+    capability_namespaces: tuple[str, ...]
+    supported_action_classes: tuple[ActionClass, ...]
+    enabled: bool
+    health_status: HealthStatus
+    is_site_primary: bool = False
+
+
+@dataclass(frozen=True)
+class CapabilityRoute:
+    capability_namespace: str
+    connector_instance_id: str
+    supported_action_classes: tuple[ActionClass, ...] = ()
+    priority: int = 100
+
+
+@dataclass(frozen=True)
+class CapabilityRoutePolicy:
+    policy_version: int
+    organization_id: str
+    site_id: str
+    routes: tuple[CapabilityRoute, ...]
+    organization_default_connector_id: str | None = None
+
+
+@dataclass(frozen=True)
+class ConnectorResolutionResult:
+    resolution_id: str
+    request_id: str
+    organization_id: str
+    site_id: str
+    actor_id: str
+    action_class: ActionClass
+    capability_namespace: str
+    status: ResolutionStatus
+    source: ResolutionSource
+    reason_code: ReasonCode
+    connector_instance_id: str | None
+    idempotency_key: str | None
+    correlation_id: str | None
+    policy_version: int
+    candidate_connector_ids: tuple[str, ...]
+    evaluated_utc: str
+
+    def as_record(self) -> dict[str, object]:
+        return {
+            "schema_version": "1.0.0",
+            "resolution_id": self.resolution_id,
+            "request_id": self.request_id,
+            "organization_id": self.organization_id,
+            "site_id": self.site_id,
+            "actor_id": self.actor_id,
+            "action_class": self.action_class,
+            "capability_namespace": self.capability_namespace,
+            "status": self.status,
+            "source": self.source,
+            "reason_code": self.reason_code,
+            "connector_instance_id": self.connector_instance_id,
+            "idempotency_key": self.idempotency_key,
+            "correlation_id": self.correlation_id,
+            "policy_version": self.policy_version,
+            "candidate_connector_ids": list(self.candidate_connector_ids),
+            "evaluated_utc": self.evaluated_utc,
+        }
+
+
+def _require_scope(value: str, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"connector routing requires {field_name}")
+    return value.strip()
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _is_entry_eligible(
+    entry: ConnectorRegistryEntry,
+    *,
+    action_class: ActionClass,
+    capability_namespace: str,
+) -> tuple[bool, ReasonCode]:
+    if not entry.enabled:
+        return False, "no_eligible_connector"
+    if entry.health_status == "unhealthy":
+        return False, "connector_unhealthy"
+    if capability_namespace not in entry.capability_namespaces:
+        return False, "unsupported_capability"
+    if action_class not in entry.supported_action_classes:
+        return False, "unsupported_action"
+    return True, "ok"
+
+
+def _result(
+    *,
+    request_id: str,
+    organization_id: str,
+    site_id: str,
+    actor_id: str,
+    action_class: ActionClass,
+    capability_namespace: str,
+    status: ResolutionStatus,
+    source: ResolutionSource,
+    reason_code: ReasonCode,
+    connector_instance_id: str | None,
+    idempotency_key: str | None,
+    correlation_id: str | None,
+    policy_version: int,
+    candidate_connector_ids: tuple[str, ...],
+    resolution_id: str | None,
+    evaluated_utc: datetime | None,
+) -> ConnectorResolutionResult:
+    return ConnectorResolutionResult(
+        resolution_id=resolution_id or str(uuid.uuid4()),
+        request_id=request_id,
+        organization_id=organization_id,
+        site_id=site_id,
+        actor_id=actor_id,
+        action_class=action_class,
+        capability_namespace=capability_namespace,
+        status=status,
+        source=source,
+        reason_code=reason_code,
+        connector_instance_id=connector_instance_id,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+        policy_version=policy_version,
+        candidate_connector_ids=tuple(sorted(candidate_connector_ids)),
+        evaluated_utc=(evaluated_utc or datetime.now(UTC)).isoformat().replace("+00:00", "Z"),
+    )
+
+
+def resolve_connector(
+    entries: list[ConnectorRegistryEntry],
+    policy: CapabilityRoutePolicy,
+    *,
+    request_id: str,
+    actor_id: str,
+    action_class: ActionClass,
+    capability_namespace: str,
+    operation_override_connector_id: str | None = None,
+    idempotency_key: str | None = None,
+    correlation_id: str | None = None,
+    resolution_id: str | None = None,
+    evaluated_utc: datetime | None = None,
+) -> ConnectorResolutionResult:
+    """Resolve one connector deterministically without side effects."""
+    request_id = _require_scope(request_id, "request_id")
+    actor_id = _require_scope(actor_id, "actor_id")
+    organization_id = _require_scope(policy.organization_id, "organization_id")
+    site_id = _require_scope(policy.site_id, "site_id")
+
+    scoped_entries = [
+        entry
+        for entry in entries
+        if entry.organization_id == organization_id and entry.site_id == site_id
+    ]
+    scoped_entries.sort(key=lambda item: item.connector_instance_id)
+    candidate_ids = tuple(entry.connector_instance_id for entry in scoped_entries)
+
+    if action_class in _MUTATION_ACTIONS and (not idempotency_key or not idempotency_key.strip()):
+        return _result(
+            request_id=request_id,
+            organization_id=organization_id,
+            site_id=site_id,
+            actor_id=actor_id,
+            action_class=action_class,
+            capability_namespace=capability_namespace,
+            status="error",
+            source="no_route",
+            reason_code="missing_idempotency_key",
+            connector_instance_id=None,
+            idempotency_key=None,
+            correlation_id=correlation_id,
+            policy_version=policy.policy_version,
+            candidate_connector_ids=candidate_ids,
+            resolution_id=resolution_id,
+            evaluated_utc=evaluated_utc,
+        )
+
+    if operation_override_connector_id:
+        override = next(
+            (entry for entry in scoped_entries if entry.connector_instance_id == operation_override_connector_id),
+            None,
+        )
+        if override is None:
+            return _result(
+                request_id=request_id,
+                organization_id=organization_id,
+                site_id=site_id,
+                actor_id=actor_id,
+                action_class=action_class,
+                capability_namespace=capability_namespace,
+                status="error",
+                source="operation_override",
+                reason_code="override_not_found",
+                connector_instance_id=None,
+                idempotency_key=idempotency_key,
+                correlation_id=correlation_id,
+                policy_version=policy.policy_version,
+                candidate_connector_ids=candidate_ids,
+                resolution_id=resolution_id,
+                evaluated_utc=evaluated_utc,
+            )
+        eligible, reason = _is_entry_eligible(
+            override,
+            action_class=action_class,
+            capability_namespace=capability_namespace,
+        )
+        if not eligible:
+            return _result(
+                request_id=request_id,
+                organization_id=organization_id,
+                site_id=site_id,
+                actor_id=actor_id,
+                action_class=action_class,
+                capability_namespace=capability_namespace,
+                status="error",
+                source="operation_override",
+                reason_code="override_ineligible" if reason != "connector_unhealthy" else "connector_unhealthy",
+                connector_instance_id=None,
+                idempotency_key=idempotency_key,
+                correlation_id=correlation_id,
+                policy_version=policy.policy_version,
+                candidate_connector_ids=candidate_ids,
+                resolution_id=resolution_id,
+                evaluated_utc=evaluated_utc,
+            )
+        return _result(
+            request_id=request_id,
+            organization_id=organization_id,
+            site_id=site_id,
+            actor_id=actor_id,
+            action_class=action_class,
+            capability_namespace=capability_namespace,
+            status="resolved",
+            source="operation_override",
+            reason_code="ok",
+            connector_instance_id=override.connector_instance_id,
+            idempotency_key=idempotency_key,
+            correlation_id=correlation_id,
+            policy_version=policy.policy_version,
+            candidate_connector_ids=candidate_ids,
+            resolution_id=resolution_id,
+            evaluated_utc=evaluated_utc,
+        )
+
+    matching_routes = [
+        route
+        for route in policy.routes
+        if route.capability_namespace == capability_namespace
+        and (not route.supported_action_classes or action_class in route.supported_action_classes)
+    ]
+    matching_routes.sort(key=lambda route: (route.priority, route.connector_instance_id))
+
+    if matching_routes:
+        best_priority = matching_routes[0].priority
+        top_routes = [route for route in matching_routes if route.priority == best_priority]
+        route_ids = {route.connector_instance_id for route in top_routes}
+        if len(route_ids) > 1:
+            return _result(
+                request_id=request_id,
+                organization_id=organization_id,
+                site_id=site_id,
+                actor_id=actor_id,
+                action_class=action_class,
+                capability_namespace=capability_namespace,
+                status="error",
+                source="capability_route",
+                reason_code="ambiguous_route",
+                connector_instance_id=None,
+                idempotency_key=idempotency_key,
+                correlation_id=correlation_id,
+                policy_version=policy.policy_version,
+                candidate_connector_ids=tuple(sorted(route_ids)),
+                resolution_id=resolution_id,
+                evaluated_utc=evaluated_utc,
+            )
+
+        routed_id = top_routes[0].connector_instance_id
+        routed_entry = next((entry for entry in scoped_entries if entry.connector_instance_id == routed_id), None)
+        if routed_entry:
+            eligible, reason = _is_entry_eligible(
+                routed_entry,
+                action_class=action_class,
+                capability_namespace=capability_namespace,
+            )
+            if eligible:
+                return _result(
+                    request_id=request_id,
+                    organization_id=organization_id,
+                    site_id=site_id,
+                    actor_id=actor_id,
+                    action_class=action_class,
+                    capability_namespace=capability_namespace,
+                    status="resolved",
+                    source="capability_route",
+                    reason_code="ok",
+                    connector_instance_id=routed_entry.connector_instance_id,
+                    idempotency_key=idempotency_key,
+                    correlation_id=correlation_id,
+                    policy_version=policy.policy_version,
+                    candidate_connector_ids=candidate_ids,
+                    resolution_id=resolution_id,
+                    evaluated_utc=evaluated_utc,
+                )
+            if reason == "connector_unhealthy":
+                return _result(
+                    request_id=request_id,
+                    organization_id=organization_id,
+                    site_id=site_id,
+                    actor_id=actor_id,
+                    action_class=action_class,
+                    capability_namespace=capability_namespace,
+                    status="error",
+                    source="capability_route",
+                    reason_code="connector_unhealthy",
+                    connector_instance_id=None,
+                    idempotency_key=idempotency_key,
+                    correlation_id=correlation_id,
+                    policy_version=policy.policy_version,
+                    candidate_connector_ids=candidate_ids,
+                    resolution_id=resolution_id,
+                    evaluated_utc=evaluated_utc,
+                )
+
+    primaries = [
+        entry
+        for entry in scoped_entries
+        if entry.is_site_primary
+    ]
+    primaries.sort(key=lambda item: item.connector_instance_id)
+    eligible_primaries = [
+        entry for entry in primaries
+        if _is_entry_eligible(entry, action_class=action_class, capability_namespace=capability_namespace)[0]
+    ]
+    if len(eligible_primaries) == 1:
+        selected = eligible_primaries[0]
+        return _result(
+            request_id=request_id,
+            organization_id=organization_id,
+            site_id=site_id,
+            actor_id=actor_id,
+            action_class=action_class,
+            capability_namespace=capability_namespace,
+            status="resolved",
+            source="site_primary",
+            reason_code="ok",
+            connector_instance_id=selected.connector_instance_id,
+            idempotency_key=idempotency_key,
+            correlation_id=correlation_id,
+            policy_version=policy.policy_version,
+            candidate_connector_ids=candidate_ids,
+            resolution_id=resolution_id,
+            evaluated_utc=evaluated_utc,
+        )
+    if len(eligible_primaries) > 1:
+        return _result(
+            request_id=request_id,
+            organization_id=organization_id,
+            site_id=site_id,
+            actor_id=actor_id,
+            action_class=action_class,
+            capability_namespace=capability_namespace,
+            status="error",
+            source="site_primary",
+            reason_code="ambiguous_route",
+            connector_instance_id=None,
+            idempotency_key=idempotency_key,
+            correlation_id=correlation_id,
+            policy_version=policy.policy_version,
+            candidate_connector_ids=tuple(entry.connector_instance_id for entry in eligible_primaries),
+            resolution_id=resolution_id,
+            evaluated_utc=evaluated_utc,
+        )
+
+    if policy.organization_default_connector_id:
+        default_entry = next(
+            (entry for entry in scoped_entries if entry.connector_instance_id == policy.organization_default_connector_id),
+            None,
+        )
+        if default_entry:
+            eligible, reason = _is_entry_eligible(
+                default_entry,
+                action_class=action_class,
+                capability_namespace=capability_namespace,
+            )
+            if eligible:
+                return _result(
+                    request_id=request_id,
+                    organization_id=organization_id,
+                    site_id=site_id,
+                    actor_id=actor_id,
+                    action_class=action_class,
+                    capability_namespace=capability_namespace,
+                    status="resolved",
+                    source="organization_default",
+                    reason_code="ok",
+                    connector_instance_id=default_entry.connector_instance_id,
+                    idempotency_key=idempotency_key,
+                    correlation_id=correlation_id,
+                    policy_version=policy.policy_version,
+                    candidate_connector_ids=candidate_ids,
+                    resolution_id=resolution_id,
+                    evaluated_utc=evaluated_utc,
+                )
+            if reason == "connector_unhealthy":
+                return _result(
+                    request_id=request_id,
+                    organization_id=organization_id,
+                    site_id=site_id,
+                    actor_id=actor_id,
+                    action_class=action_class,
+                    capability_namespace=capability_namespace,
+                    status="error",
+                    source="organization_default",
+                    reason_code="connector_unhealthy",
+                    connector_instance_id=None,
+                    idempotency_key=idempotency_key,
+                    correlation_id=correlation_id,
+                    policy_version=policy.policy_version,
+                    candidate_connector_ids=candidate_ids,
+                    resolution_id=resolution_id,
+                    evaluated_utc=evaluated_utc,
+                )
+
+    return _result(
+        request_id=request_id,
+        organization_id=organization_id,
+        site_id=site_id,
+        actor_id=actor_id,
+        action_class=action_class,
+        capability_namespace=capability_namespace,
+        status="error",
+        source="no_route",
+        reason_code="no_eligible_connector",
+        connector_instance_id=None,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+        policy_version=policy.policy_version,
+        candidate_connector_ids=candidate_ids,
+        resolution_id=resolution_id,
+        evaluated_utc=evaluated_utc,
+    )

--- a/src/lumina/connector_routing/router.py
+++ b/src/lumina/connector_routing/router.py
@@ -127,17 +127,27 @@ def _utc_now() -> str:
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 
+def _normalize_optional(value: str | None) -> str | None:
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
 def _is_entry_eligible(
     entry: ConnectorRegistryEntry,
     *,
     action_class: ActionClass,
     capability_namespace: str,
 ) -> tuple[bool, ReasonCode]:
+    normalized_capabilities = {
+        capability.strip() for capability in entry.capability_namespaces if capability and capability.strip()
+    }
     if not entry.enabled:
         return False, "no_eligible_connector"
     if entry.health_status == "unhealthy":
         return False, "connector_unhealthy"
-    if capability_namespace not in entry.capability_namespaces:
+    if capability_namespace not in normalized_capabilities:
         return False, "unsupported_capability"
     if action_class not in entry.supported_action_classes:
         return False, "unsupported_action"
@@ -179,7 +189,9 @@ def _result(
         correlation_id=correlation_id,
         policy_version=policy_version,
         candidate_connector_ids=tuple(sorted(candidate_connector_ids)),
-        evaluated_utc=(evaluated_utc or datetime.now(UTC)).isoformat().replace("+00:00", "Z"),
+        evaluated_utc=(
+            evaluated_utc.isoformat().replace("+00:00", "Z") if evaluated_utc is not None else _utc_now()
+        ),
     )
 
 
@@ -200,8 +212,12 @@ def resolve_connector(
     """Resolve one connector deterministically without side effects."""
     request_id = _require_scope(request_id, "request_id")
     actor_id = _require_scope(actor_id, "actor_id")
+    capability_namespace = _require_scope(capability_namespace, "capability_namespace")
     organization_id = _require_scope(policy.organization_id, "organization_id")
     site_id = _require_scope(policy.site_id, "site_id")
+    operation_override_connector_id = _normalize_optional(operation_override_connector_id)
+    idempotency_key = _normalize_optional(idempotency_key)
+    correlation_id = _normalize_optional(correlation_id)
 
     scoped_entries = [
         entry
@@ -211,7 +227,7 @@ def resolve_connector(
     scoped_entries.sort(key=lambda item: item.connector_instance_id)
     candidate_ids = tuple(entry.connector_instance_id for entry in scoped_entries)
 
-    if action_class in _MUTATION_ACTIONS and (not idempotency_key or not idempotency_key.strip()):
+    if action_class in _MUTATION_ACTIONS and not idempotency_key:
         return _result(
             request_id=request_id,
             organization_id=organization_id,
@@ -231,7 +247,7 @@ def resolve_connector(
             evaluated_utc=evaluated_utc,
         )
 
-    if operation_override_connector_id:
+    if operation_override_connector_id is not None:
         override = next(
             (entry for entry in scoped_entries if entry.connector_instance_id == operation_override_connector_id),
             None,
@@ -301,7 +317,7 @@ def resolve_connector(
     matching_routes = [
         route
         for route in policy.routes
-        if route.capability_namespace == capability_namespace
+        if route.capability_namespace.strip() == capability_namespace
         and (not route.supported_action_classes or action_class in route.supported_action_classes)
     ]
     matching_routes.sort(key=lambda route: (route.priority, route.connector_instance_id))

--- a/standards/capability-route-policy-schema-v1.json
+++ b/standards/capability-route-policy-schema-v1.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://projectlumina.org/standards/capability-route-policy-schema-v1.json",
+  "schema_version": "1.0.0",
+  "last_updated": "2026-07-26",
+  "title": "Capability Route Policy Schema V1",
+  "description": "Deterministic connector routing policy with precedence-aware capability routes.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "policy_version",
+    "organization_id",
+    "site_id",
+    "routes"
+  ],
+  "properties": {
+    "policy_version": {"type": "integer", "minimum": 1},
+    "organization_id": {"type": "string", "minLength": 1},
+    "site_id": {"type": "string", "minLength": 1},
+    "organization_default_connector_id": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "capability-route-policy-schema-v1.json#/$defs/route"
+      }
+    }
+  },
+  "$defs": {
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "capability_namespace",
+        "connector_instance_id",
+        "priority"
+      ],
+      "properties": {
+        "capability_namespace": {
+          "$ref": "business-operation-request-schema-v1.json#/$defs/capability_namespace"
+        },
+        "connector_instance_id": {"type": "string", "minLength": 1},
+        "supported_action_classes": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "business-operation-request-schema-v1.json#/$defs/action_class"
+          }
+        },
+        "priority": {"type": "integer", "minimum": 1},
+        "metadata": {
+          "$ref": "business-operation-request-schema-v1.json#/$defs/safe_object"
+        }
+      }
+    }
+  }
+}

--- a/standards/connector-registry-entry-schema-v1.json
+++ b/standards/connector-registry-entry-schema-v1.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://projectlumina.org/standards/connector-registry-entry-schema-v1.json",
+  "schema_version": "1.0.0",
+  "last_updated": "2026-07-26",
+  "title": "Connector Registry Entry Schema V1",
+  "description": "Canonical provider-neutral connector registry entry scoped to organization/site.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "organization_id",
+    "site_id",
+    "connector_instance_id",
+    "capability_namespaces",
+    "supported_action_classes",
+    "enabled",
+    "health_status"
+  ],
+  "properties": {
+    "organization_id": {"type": "string", "minLength": 1},
+    "site_id": {"type": "string", "minLength": 1},
+    "connector_instance_id": {"type": "string", "minLength": 1},
+    "provider_family": {"type": ["string", "null"], "minLength": 1},
+    "capability_namespaces": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "business-operation-request-schema-v1.json#/$defs/capability_namespace"
+      }
+    },
+    "supported_action_classes": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "business-operation-request-schema-v1.json#/$defs/action_class"
+      }
+    },
+    "enabled": {"type": "boolean"},
+    "health_status": {
+      "type": "string",
+      "enum": ["healthy", "degraded", "unhealthy"]
+    },
+    "is_site_primary": {"type": "boolean"},
+    "health_checked_utc": {
+      "type": ["string", "null"],
+      "format": "date-time"
+    },
+    "metadata": {
+      "$ref": "business-operation-request-schema-v1.json#/$defs/safe_object"
+    }
+  }
+}

--- a/standards/connector-resolution-result-schema-v1.json
+++ b/standards/connector-resolution-result-schema-v1.json
@@ -8,6 +8,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
+    "schema_version",
     "resolution_id",
     "request_id",
     "organization_id",

--- a/standards/connector-resolution-result-schema-v1.json
+++ b/standards/connector-resolution-result-schema-v1.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://projectlumina.org/standards/connector-resolution-result-schema-v1.json",
+  "schema_version": "1.0.0",
+  "last_updated": "2026-07-26",
+  "title": "Connector Resolution Result Schema V1",
+  "description": "Transcript-free auditable connector routing decision result.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "resolution_id",
+    "request_id",
+    "organization_id",
+    "site_id",
+    "actor_id",
+    "action_class",
+    "capability_namespace",
+    "status",
+    "source",
+    "reason_code",
+    "policy_version",
+    "candidate_connector_ids",
+    "evaluated_utc"
+  ],
+  "properties": {
+    "schema_version": {"type": "string", "const": "1.0.0"},
+    "resolution_id": {"type": "string", "minLength": 1},
+    "request_id": {"type": "string", "minLength": 1},
+    "organization_id": {"type": "string", "minLength": 1},
+    "site_id": {"type": "string", "minLength": 1},
+    "actor_id": {"type": "string", "minLength": 1},
+    "action_class": {
+      "$ref": "business-operation-request-schema-v1.json#/$defs/action_class"
+    },
+    "capability_namespace": {
+      "$ref": "business-operation-request-schema-v1.json#/$defs/capability_namespace"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["resolved", "error"]
+    },
+    "source": {
+      "type": "string",
+      "enum": [
+        "operation_override",
+        "capability_route",
+        "site_primary",
+        "organization_default",
+        "no_route"
+      ]
+    },
+    "reason_code": {
+      "type": "string",
+      "enum": [
+        "ok",
+        "missing_idempotency_key",
+        "override_not_found",
+        "override_ineligible",
+        "ambiguous_route",
+        "capability_route_not_found",
+        "site_primary_not_found",
+        "organization_default_not_found",
+        "unsupported_capability",
+        "unsupported_action",
+        "connector_unhealthy",
+        "no_eligible_connector"
+      ]
+    },
+    "connector_instance_id": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "idempotency_key": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "correlation_id": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "policy_version": {"type": "integer", "minimum": 1},
+    "candidate_connector_ids": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1},
+      "uniqueItems": true
+    },
+    "evaluated_utc": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "metadata": {
+      "$ref": "business-operation-request-schema-v1.json#/$defs/safe_object"
+    }
+  }
+}

--- a/tests/test_connector_routing.py
+++ b/tests/test_connector_routing.py
@@ -97,6 +97,22 @@ def test_capability_route_used_before_site_primary() -> None:
 
 
 @pytest.mark.unit
+def test_capability_namespace_is_normalized_for_matching() -> None:
+    result = resolve_connector(
+        [_entry("conn-cap", capabilities=(" service/work-order ",))],
+        _policy(routes=(CapabilityRoute(" service/work-order ", "conn-cap", ("query",), 1),)),
+        request_id="req-3b",
+        actor_id="actor-a",
+        action_class="query",
+        capability_namespace="  service/work-order  ",
+    )
+
+    assert result.status == "resolved"
+    assert result.source == "capability_route"
+    assert result.connector_instance_id == "conn-cap"
+
+
+@pytest.mark.unit
 def test_ambiguous_capability_route_is_error() -> None:
     result = resolve_connector(
         [_entry("conn-a"), _entry("conn-b")],

--- a/tests/test_connector_routing.py
+++ b/tests/test_connector_routing.py
@@ -1,0 +1,183 @@
+"""Deterministic connector-routing precedence tests for Slice 31."""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from lumina.connector_routing.router import (
+    CapabilityRoute,
+    CapabilityRoutePolicy,
+    ConnectorRegistryEntry,
+    resolve_connector,
+)
+
+
+def _entry(
+    connector_id: str,
+    *,
+    enabled: bool = True,
+    health_status: str = "healthy",
+    is_site_primary: bool = False,
+    capabilities: tuple[str, ...] = ("service/work-order", "inventory"),
+    actions: tuple[str, ...] = ("query", "request_commit"),
+) -> ConnectorRegistryEntry:
+    return ConnectorRegistryEntry(
+        organization_id="org-a",
+        site_id="site-a",
+        connector_instance_id=connector_id,
+        capability_namespaces=capabilities,
+        supported_action_classes=actions,  # type: ignore[arg-type]
+        enabled=enabled,
+        health_status=health_status,  # type: ignore[arg-type]
+        is_site_primary=is_site_primary,
+    )
+
+
+def _policy(
+    routes: tuple[CapabilityRoute, ...] = (),
+    *,
+    default_id: str | None = None,
+) -> CapabilityRoutePolicy:
+    return CapabilityRoutePolicy(
+        policy_version=1,
+        organization_id="org-a",
+        site_id="site-a",
+        routes=routes,
+        organization_default_connector_id=default_id,
+    )
+
+
+@pytest.mark.unit
+def test_operation_override_has_highest_precedence() -> None:
+    result = resolve_connector(
+        [_entry("conn-a"), _entry("conn-b", is_site_primary=True)],
+        _policy(routes=(CapabilityRoute("service/work-order", "conn-b", ("query",), 10),)),
+        request_id="req-1",
+        actor_id="actor-a",
+        action_class="query",
+        capability_namespace="service/work-order",
+        operation_override_connector_id="conn-a",
+    )
+
+    assert result.status == "resolved"
+    assert result.source == "operation_override"
+    assert result.connector_instance_id == "conn-a"
+
+
+@pytest.mark.unit
+def test_requires_idempotency_key_for_mutation_actions() -> None:
+    result = resolve_connector(
+        [_entry("conn-a", actions=("request_commit",))],
+        _policy(),
+        request_id="req-2",
+        actor_id="actor-a",
+        action_class="request_commit",
+        capability_namespace="service/work-order",
+    )
+
+    assert result.status == "error"
+    assert result.reason_code == "missing_idempotency_key"
+
+
+@pytest.mark.unit
+def test_capability_route_used_before_site_primary() -> None:
+    result = resolve_connector(
+        [_entry("conn-primary", is_site_primary=True), _entry("conn-cap")],
+        _policy(routes=(CapabilityRoute("service/work-order", "conn-cap", ("query",), 1),)),
+        request_id="req-3",
+        actor_id="actor-a",
+        action_class="query",
+        capability_namespace="service/work-order",
+    )
+
+    assert result.status == "resolved"
+    assert result.source == "capability_route"
+    assert result.connector_instance_id == "conn-cap"
+
+
+@pytest.mark.unit
+def test_ambiguous_capability_route_is_error() -> None:
+    result = resolve_connector(
+        [_entry("conn-a"), _entry("conn-b")],
+        _policy(
+            routes=(
+                CapabilityRoute("service/work-order", "conn-a", ("query",), 1),
+                CapabilityRoute("service/work-order", "conn-b", ("query",), 1),
+            ),
+        ),
+        request_id="req-4",
+        actor_id="actor-a",
+        action_class="query",
+        capability_namespace="service/work-order",
+    )
+
+    assert result.status == "error"
+    assert result.reason_code == "ambiguous_route"
+    assert result.source == "capability_route"
+
+
+@pytest.mark.unit
+def test_site_primary_used_when_no_route() -> None:
+    result = resolve_connector(
+        [_entry("conn-primary", is_site_primary=True)],
+        _policy(),
+        request_id="req-5",
+        actor_id="actor-a",
+        action_class="query",
+        capability_namespace="service/work-order",
+    )
+
+    assert result.status == "resolved"
+    assert result.source == "site_primary"
+    assert result.connector_instance_id == "conn-primary"
+
+
+@pytest.mark.unit
+def test_org_default_used_after_site_primary() -> None:
+    result = resolve_connector(
+        [_entry("conn-default")],
+        _policy(default_id="conn-default"),
+        request_id="req-6",
+        actor_id="actor-a",
+        action_class="query",
+        capability_namespace="service/work-order",
+    )
+
+    assert result.status == "resolved"
+    assert result.source == "organization_default"
+    assert result.connector_instance_id == "conn-default"
+
+
+@pytest.mark.unit
+def test_unhealthy_connector_returns_structured_error() -> None:
+    result = resolve_connector(
+        [_entry("conn-a", health_status="unhealthy", is_site_primary=True)],
+        _policy(),
+        request_id="req-7",
+        actor_id="actor-a",
+        action_class="query",
+        capability_namespace="service/work-order",
+    )
+
+    assert result.status == "error"
+    assert result.reason_code == "no_eligible_connector"
+
+
+@pytest.mark.unit
+def test_result_record_is_stable_and_transcript_free() -> None:
+    result = resolve_connector(
+        [_entry("conn-a", is_site_primary=True)],
+        _policy(),
+        request_id="req-8",
+        actor_id="actor-a",
+        action_class="query",
+        capability_namespace="service/work-order",
+        resolution_id="resolution-1",
+        evaluated_utc=datetime(2026, 7, 26, tzinfo=UTC),
+    )
+
+    record = result.as_record()
+    assert record["resolution_id"] == "resolution-1"
+    assert record["evaluated_utc"] == "2026-07-26T00:00:00Z"
+    assert "transcript" not in str(record).lower()

--- a/tests/test_connector_routing_contracts.py
+++ b/tests/test_connector_routing_contracts.py
@@ -1,0 +1,173 @@
+"""Schema and contract validation tests for Slice 31 connector routing."""
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from lumina.connector_routing.router import (
+    CapabilityRoute,
+    CapabilityRoutePolicy,
+    ConnectorRegistryEntry,
+    resolve_connector,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+STANDARDS = REPO_ROOT / "standards"
+
+
+def _schema(name: str) -> dict:
+    return json.loads((STANDARDS / name).read_text(encoding="utf-8"))
+
+
+SCHEMA_FILES = [
+    STANDARDS / "connector-registry-entry-schema-v1.json",
+    STANDARDS / "capability-route-policy-schema-v1.json",
+    STANDARDS / "connector-resolution-result-schema-v1.json",
+    STANDARDS / "business-operation-request-schema-v1.json",
+]
+
+
+def _store() -> dict[str, dict]:
+    store: dict[str, dict] = {}
+    for schema_path in SCHEMA_FILES:
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        store[schema_path.name] = schema
+        store[schema_path.resolve().as_uri()] = schema
+        schema_id = schema.get("$id")
+        if isinstance(schema_id, str) and schema_id:
+            store[schema_id] = schema
+    return store
+
+
+STORE = _store()
+
+
+def _validator(name: str) -> jsonschema.Draft202012Validator:
+    schema_path = STANDARDS / name
+    schema = _schema(name)
+    resolver = jsonschema.RefResolver(
+        base_uri=f"{schema_path.parent.as_uri()}/",
+        referrer=schema,
+        store=STORE,
+    )
+    return jsonschema.Draft202012Validator(
+        schema,
+        resolver=resolver,
+        format_checker=jsonschema.FormatChecker(),
+    )
+
+
+@pytest.mark.unit
+def test_registry_entry_schema_accepts_valid_payload() -> None:
+    payload = {
+        "organization_id": "org-a",
+        "site_id": "site-a",
+        "connector_instance_id": "conn-a",
+        "provider_family": "erpnext",
+        "capability_namespaces": ["service/work-order"],
+        "supported_action_classes": ["query", "request_commit"],
+        "enabled": True,
+        "health_status": "healthy",
+        "is_site_primary": True,
+        "health_checked_utc": "2026-07-26T00:00:00Z",
+        "metadata": {"notes": "stable"},
+    }
+    _validator("connector-registry-entry-schema-v1.json").validate(payload)
+
+
+@pytest.mark.unit
+def test_route_policy_schema_accepts_valid_payload() -> None:
+    payload = {
+        "policy_version": 1,
+        "organization_id": "org-a",
+        "site_id": "site-a",
+        "organization_default_connector_id": "conn-default",
+        "routes": [
+            {
+                "capability_namespace": "service/work-order",
+                "connector_instance_id": "conn-a",
+                "supported_action_classes": ["query"],
+                "priority": 1,
+            }
+        ],
+    }
+    _validator("capability-route-policy-schema-v1.json").validate(payload)
+
+
+@pytest.mark.unit
+def test_result_schema_validates_router_record() -> None:
+    policy = CapabilityRoutePolicy(
+        policy_version=1,
+        organization_id="org-a",
+        site_id="site-a",
+        routes=(CapabilityRoute("service/work-order", "conn-a", ("query",), 1),),
+    )
+    entries = [
+        ConnectorRegistryEntry(
+            organization_id="org-a",
+            site_id="site-a",
+            connector_instance_id="conn-a",
+            capability_namespaces=("service/work-order",),
+            supported_action_classes=("query",),
+            enabled=True,
+            health_status="healthy",
+            is_site_primary=False,
+        )
+    ]
+    result = resolve_connector(
+        entries,
+        policy,
+        request_id="req-a",
+        actor_id="actor-a",
+        action_class="query",
+        capability_namespace="service/work-order",
+        resolution_id="resolution-a",
+        evaluated_utc=datetime(2026, 7, 26, tzinfo=UTC),
+    )
+    record = result.as_record()
+    _validator("connector-resolution-result-schema-v1.json").validate(record)
+
+
+@pytest.mark.unit
+def test_registry_entry_rejects_nested_secret_key() -> None:
+    payload = {
+        "organization_id": "org-a",
+        "site_id": "site-a",
+        "connector_instance_id": "conn-a",
+        "capability_namespaces": ["service/work-order"],
+        "supported_action_classes": ["query"],
+        "enabled": True,
+        "health_status": "healthy",
+        "metadata": {"nested": {"token": "forbidden"}},
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        _validator("connector-registry-entry-schema-v1.json").validate(payload)
+
+
+@pytest.mark.unit
+def test_result_schema_rejects_unknown_reason_code() -> None:
+    payload = {
+        "schema_version": "1.0.0",
+        "resolution_id": "resolution-a",
+        "request_id": "req-a",
+        "organization_id": "org-a",
+        "site_id": "site-a",
+        "actor_id": "actor-a",
+        "action_class": "query",
+        "capability_namespace": "service/work-order",
+        "status": "error",
+        "source": "no_route",
+        "reason_code": "made_up_reason",
+        "connector_instance_id": None,
+        "idempotency_key": None,
+        "correlation_id": None,
+        "policy_version": 1,
+        "candidate_connector_ids": [],
+        "evaluated_utc": "2026-07-26T00:00:00Z",
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        _validator("connector-resolution-result-schema-v1.json").validate(payload)


### PR DESCRIPTION
## 🛑 Wait! Before You Submit...
Project Lumina operates on a strict Accountability by Design philosophy. This PR is scoped to deterministic contracts and pure routing logic.

### 📋 Architectural Compliance Checklist
- [x] Tests Passed: I ran deterministic Slice 31 targeted tests and manifest integrity checks.
- [ ] Tests Passed (full preintegration): run-preintegration-scenarios.ps1 not yet run in this PR scope.
- [x] CTL Integrity: No append-only chain mutation logic changed in this PR.
- [x] Domain Separation: Routing core is domain-agnostic and contains no hardcoded subject/domain behavior.
- [x] Pseudonymity: No raw transcript or PII-at-rest paths introduced.
- [x] Traceability Proof: Included a sample routing decision record below.

---

## 📝 Description of Changes
This is PR 1 for Slice 31.

It adds the initial connector routing contracts and a pure deterministic resolver core without API wiring or execution authority changes.

Scope included:
- New schema contracts:
  - standards/connector-registry-entry-schema-v1.json
  - standards/capability-route-policy-schema-v1.json
  - standards/connector-resolution-result-schema-v1.json
- New deterministic routing core:
  - src/lumina/connector_routing/router.py
  - src/lumina/connector_routing/__init__.py
- New tests:
  - tests/test_connector_routing.py
  - tests/test_connector_routing_contracts.py
- Manifest updated and hashes regenerated in docs/MANIFEST.yaml.

Deterministic precedence implemented:
1. operation-level override
2. capability route
3. site primary
4. organization default
5. no-route failure

Validation run:
- python -m pytest tests/test_connector_routing.py tests/test_connector_routing_contracts.py -q
- python -m pytest tests/test_system_log_integrity.py::TestManifestIntegrity::test_manifest_check_passes -q

Out of scope for this PR:
- API preflight wiring
- ledger/audit runtime handler integration
- provider-specific execution clients

---

## 🔄 Type of Change
- [x] Domain Pack / Contract Layer (new standards schemas)
- [x] Core deterministic routing logic
- [ ] Governance/Security pipeline mutation
- [ ] Documentation only

---

## 🧪 Traceability Proof (Mandatory)
Sample connector resolution record generated by the deterministic resolver:

{
  "schema_version": "1.0.0",
  "resolution_id": "resolution-a",
  "request_id": "req-a",
  "organization_id": "org-a",
  "site_id": "site-a",
  "actor_id": "actor-a",
  "action_class": "query",
  "capability_namespace": "service/work-order",
  "status": "resolved",
  "source": "capability_route",
  "reason_code": "ok",
  "connector_instance_id": "conn-a",
  "idempotency_key": null,
  "correlation_id": null,
  "policy_version": 1,
  "candidate_connector_ids": ["conn-a"],
  "evaluated_utc": "2026-07-26T00:00:00Z"
}

---

## 🌍 Domain Impact (For Core Changes Only)
Tested as domain-neutral routing logic and schema validation only.
No domain-pack-specific execution paths were added.