### PR TITLE
Slice 31 PR2: connector routing preflight API + audit trace wiring

### DIFF
--- a/docs/MANIFEST.yaml
+++ b/docs/MANIFEST.yaml
@@ -1,5 +1,5 @@
 schema_version: 1.0.0
-last_updated: 2026-07-26
+last_updated: 2026-07-30
 artifacts:
 - path: docs/5-standards/manifest-regen-policy.md
   type: doc

--- a/src/lumina/api/models.py
+++ b/src/lumina/api/models.py
@@ -114,6 +114,59 @@ class DecisionPrecedentConfirmationResponse(BaseModel):
     tier: str
 
 
+# ── Connector routing ───────────────────────────────────────
+
+class ConnectorRoutingRegistryEntryRequest(BaseModel):
+    organization_id: str = Field(min_length=1)
+    site_id: str = Field(min_length=1)
+    connector_instance_id: str = Field(min_length=1)
+    capability_namespaces: list[str] = Field(min_length=1)
+    supported_action_classes: list[str] = Field(min_length=1)
+    enabled: bool = True
+    health_status: str
+    is_site_primary: bool = False
+
+
+class ConnectorRoutingCapabilityRouteRequest(BaseModel):
+    capability_namespace: str = Field(min_length=1)
+    connector_instance_id: str = Field(min_length=1)
+    supported_action_classes: list[str] = Field(default_factory=list)
+    priority: int = 100
+
+
+class ConnectorRoutingPreflightRequest(BaseModel):
+    request_id: str = Field(min_length=1)
+    action_class: str = Field(min_length=1)
+    capability_namespace: str = Field(min_length=1)
+    connector_registry_entries: list[ConnectorRoutingRegistryEntryRequest] = Field(min_length=1)
+    capability_routes: list[ConnectorRoutingCapabilityRouteRequest] = Field(default_factory=list)
+    policy_version: int = 1
+    organization_default_connector_id: str | None = None
+    operation_override_connector_id: str | None = None
+    idempotency_key: str | None = None
+    correlation_id: str | None = None
+    session_id: str | None = None
+
+
+class ConnectorRoutingPreflightResponse(BaseModel):
+    resolution_id: str
+    request_id: str
+    organization_id: str
+    site_id: str
+    actor_id: str
+    action_class: str
+    capability_namespace: str
+    status: str
+    source: str
+    reason_code: str
+    connector_instance_id: str | None = None
+    idempotency_key: str | None = None
+    correlation_id: str | None = None
+    policy_version: int
+    candidate_connector_ids: list[str]
+    evaluated_utc: str
+
+
 # ── Holodeck Sandbox ─────────────────────────────────────────
 
 class HolodeckSimulateRequest(BaseModel):

--- a/src/lumina/api/routes/connector_routing.py
+++ b/src/lumina/api/routes/connector_routing.py
@@ -21,6 +21,44 @@ from lumina.system_log.commit_guard import requires_log_commit
 
 router = APIRouter()
 
+_ALLOWED_ACTION_CLASSES = frozenset({
+    "query",
+    "create_draft",
+    "update_draft",
+    "request_commit",
+    "request_cancel",
+    "sync_event",
+})
+_ALLOWED_HEALTH_STATUSES = frozenset({"healthy", "degraded", "unhealthy"})
+
+
+def _normalize_required(value: str, *, field_name: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise HTTPException(status_code=422, detail=f"{field_name} is required")
+    return normalized
+
+
+def _normalize_action_class(value: str, *, field_name: str) -> str:
+    normalized = _normalize_required(value, field_name=field_name).lower()
+    if normalized not in _ALLOWED_ACTION_CLASSES:
+        raise HTTPException(status_code=422, detail=f"Unsupported action_class '{value}'")
+    return normalized
+
+
+def _normalize_health_status(value: str, *, field_name: str) -> str:
+    normalized = _normalize_required(value, field_name=field_name).lower()
+    if normalized not in _ALLOWED_HEALTH_STATUSES:
+        raise HTTPException(status_code=422, detail=f"Unsupported health_status '{value}'")
+    return normalized
+
+
+def _normalize_action_classes(values: list[str], *, field_name: str) -> tuple[str, ...]:
+    normalized = tuple(_normalize_action_class(item, field_name=field_name) for item in values)
+    if not normalized:
+        raise HTTPException(status_code=422, detail=f"{field_name} must contain at least one action class")
+    return normalized
+
 
 def _response_from_record(record: dict[str, object]) -> ConnectorRoutingPreflightResponse:
     return ConnectorRoutingPreflightResponse(
@@ -61,29 +99,65 @@ async def preflight(
     """Resolve a scoped connector target and append transcript-free audit evidence."""
     organization_id = str(context["organization_id"])
     site_id = str(context["site_id"])
+    action_class = _normalize_action_class(req.action_class, field_name="action_class")
+    capability_namespace = _normalize_required(
+        req.capability_namespace,
+        field_name="capability_namespace",
+    )
 
     entries: list[ConnectorRegistryEntry] = []
     for entry in req.connector_registry_entries:
         if entry.organization_id != organization_id or entry.site_id != site_id:
             raise HTTPException(status_code=403, detail="Connector registry entry is outside active context")
+        connector_instance_id = _normalize_required(
+            entry.connector_instance_id,
+            field_name="connector_registry_entries.connector_instance_id",
+        )
+        capability_namespaces = tuple(
+            _normalize_required(
+                namespace,
+                field_name="connector_registry_entries.capability_namespaces",
+            )
+            for namespace in entry.capability_namespaces
+        )
+        supported_action_classes = _normalize_action_classes(
+            entry.supported_action_classes,
+            field_name="connector_registry_entries.supported_action_classes",
+        )
+        health_status = _normalize_health_status(
+            entry.health_status,
+            field_name="connector_registry_entries.health_status",
+        )
         entries.append(
             ConnectorRegistryEntry(
                 organization_id=entry.organization_id,
                 site_id=entry.site_id,
-                connector_instance_id=entry.connector_instance_id,
-                capability_namespaces=tuple(entry.capability_namespaces),
-                supported_action_classes=tuple(entry.supported_action_classes),  # type: ignore[arg-type]
+                connector_instance_id=connector_instance_id,
+                capability_namespaces=capability_namespaces,
+                supported_action_classes=supported_action_classes,
                 enabled=entry.enabled,
-                health_status=entry.health_status,  # type: ignore[arg-type]
+                health_status=health_status,
                 is_site_primary=entry.is_site_primary,
             )
         )
 
     routes = tuple(
         CapabilityRoute(
-            capability_namespace=route.capability_namespace,
-            connector_instance_id=route.connector_instance_id,
-            supported_action_classes=tuple(route.supported_action_classes),  # type: ignore[arg-type]
+            capability_namespace=_normalize_required(
+                route.capability_namespace,
+                field_name="capability_routes.capability_namespace",
+            ),
+            connector_instance_id=_normalize_required(
+                route.connector_instance_id,
+                field_name="capability_routes.connector_instance_id",
+            ),
+            supported_action_classes=tuple(
+                _normalize_action_class(
+                    action,
+                    field_name="capability_routes.supported_action_classes",
+                )
+                for action in route.supported_action_classes
+            ),
             priority=route.priority,
         )
         for route in req.capability_routes
@@ -101,10 +175,10 @@ async def preflight(
             resolve_connector,
             entries,
             policy,
-            request_id=req.request_id,
+            request_id=_normalize_required(req.request_id, field_name="request_id"),
             actor_id=str(user["sub"]),
-            action_class=req.action_class,
-            capability_namespace=req.capability_namespace,
+            action_class=action_class,
+            capability_namespace=capability_namespace,
             operation_override_connector_id=req.operation_override_connector_id,
             idempotency_key=req.idempotency_key,
             correlation_id=req.correlation_id,

--- a/src/lumina/api/routes/connector_routing.py
+++ b/src/lumina/api/routes/connector_routing.py
@@ -1,0 +1,130 @@
+"""Authenticated, scope-safe connector-routing preflight API."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from starlette.concurrency import run_in_threadpool
+
+from lumina.api import config as _cfg
+from lumina.api.dependencies import get_active_operating_context, get_authenticated_user
+from lumina.api.models import (
+    ConnectorRoutingPreflightRequest,
+    ConnectorRoutingPreflightResponse,
+)
+from lumina.connector_routing.router import (
+    CapabilityRoute,
+    CapabilityRoutePolicy,
+    ConnectorRegistryEntry,
+    resolve_connector,
+)
+from lumina.system_log.admin_operations import build_trace_event
+from lumina.system_log.commit_guard import requires_log_commit
+
+router = APIRouter()
+
+
+def _response_from_record(record: dict[str, object]) -> ConnectorRoutingPreflightResponse:
+    return ConnectorRoutingPreflightResponse(
+        resolution_id=str(record["resolution_id"]),
+        request_id=str(record["request_id"]),
+        organization_id=str(record["organization_id"]),
+        site_id=str(record["site_id"]),
+        actor_id=str(record["actor_id"]),
+        action_class=str(record["action_class"]),
+        capability_namespace=str(record["capability_namespace"]),
+        status=str(record["status"]),
+        source=str(record["source"]),
+        reason_code=str(record["reason_code"]),
+        connector_instance_id=(
+            str(record["connector_instance_id"])
+            if isinstance(record["connector_instance_id"], str)
+            else None
+        ),
+        idempotency_key=(
+            str(record["idempotency_key"]) if isinstance(record["idempotency_key"], str) else None
+        ),
+        correlation_id=(
+            str(record["correlation_id"]) if isinstance(record["correlation_id"], str) else None
+        ),
+        policy_version=int(record["policy_version"]),
+        candidate_connector_ids=[str(v) for v in record["candidate_connector_ids"]],  # type: ignore[index]
+        evaluated_utc=str(record["evaluated_utc"]),
+    )
+
+
+@router.post("/api/connector-routing/preflight", response_model=ConnectorRoutingPreflightResponse)
+@requires_log_commit
+async def preflight(
+    req: ConnectorRoutingPreflightRequest,
+    user: dict[str, object] = Depends(get_authenticated_user),
+    context: dict[str, str | None] = Depends(get_active_operating_context),
+) -> ConnectorRoutingPreflightResponse:
+    """Resolve a scoped connector target and append transcript-free audit evidence."""
+    organization_id = str(context["organization_id"])
+    site_id = str(context["site_id"])
+
+    entries: list[ConnectorRegistryEntry] = []
+    for entry in req.connector_registry_entries:
+        if entry.organization_id != organization_id or entry.site_id != site_id:
+            raise HTTPException(status_code=403, detail="Connector registry entry is outside active context")
+        entries.append(
+            ConnectorRegistryEntry(
+                organization_id=entry.organization_id,
+                site_id=entry.site_id,
+                connector_instance_id=entry.connector_instance_id,
+                capability_namespaces=tuple(entry.capability_namespaces),
+                supported_action_classes=tuple(entry.supported_action_classes),  # type: ignore[arg-type]
+                enabled=entry.enabled,
+                health_status=entry.health_status,  # type: ignore[arg-type]
+                is_site_primary=entry.is_site_primary,
+            )
+        )
+
+    routes = tuple(
+        CapabilityRoute(
+            capability_namespace=route.capability_namespace,
+            connector_instance_id=route.connector_instance_id,
+            supported_action_classes=tuple(route.supported_action_classes),  # type: ignore[arg-type]
+            priority=route.priority,
+        )
+        for route in req.capability_routes
+    )
+    policy = CapabilityRoutePolicy(
+        policy_version=req.policy_version,
+        organization_id=organization_id,
+        site_id=site_id,
+        routes=routes,
+        organization_default_connector_id=req.organization_default_connector_id,
+    )
+
+    try:
+        result = await run_in_threadpool(
+            resolve_connector,
+            entries,
+            policy,
+            request_id=req.request_id,
+            actor_id=str(user["sub"]),
+            action_class=req.action_class,
+            capability_namespace=req.capability_namespace,
+            operation_override_connector_id=req.operation_override_connector_id,
+            idempotency_key=req.idempotency_key,
+            correlation_id=req.correlation_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    record = result.as_record()
+    routing_session_id = req.session_id or "connector-routing"
+    trace_event = build_trace_event(
+        session_id=routing_session_id,
+        actor_id=str(user["sub"]),
+        event_type="other",
+        decision="connector_routing_evaluated",
+        evidence_summary={"connector_resolution_result": record},
+    )
+    await run_in_threadpool(
+        _cfg.PERSISTENCE.append_log_record,
+        routing_session_id,
+        trace_event,
+        _cfg.PERSISTENCE.get_system_ledger_path(routing_session_id),
+    )
+    return _response_from_record(record)

--- a/src/lumina/api/server.py
+++ b/src/lumina/api/server.py
@@ -136,6 +136,7 @@ from lumina.api.routes.admin import (  # noqa: E402
 )
 from lumina.api.routes.auth import router as auth_router  # noqa: E402
 from lumina.api.routes.chat import router as chat_router  # noqa: E402
+from lumina.api.routes.connector_routing import router as connector_routing_router  # noqa: E402
 from lumina.api.routes.thread_routing import router as thread_routing_router  # noqa: E402
 from lumina.api.routes.decision_precedent import router as decision_precedent_router  # noqa: E402
 from lumina.api.routes.system_log import router as system_log_router  # noqa: E402
@@ -211,6 +212,7 @@ app.add_middleware(_InFlightCounterMiddleware)
 
 # Register route groups
 app.include_router(chat_router)
+app.include_router(connector_routing_router)
 app.include_router(thread_routing_router)
 app.include_router(decision_precedent_router)
 app.include_router(auth_router)

--- a/tests/test_connector_routing_api.py
+++ b/tests/test_connector_routing_api.py
@@ -1,0 +1,236 @@
+"""Integration tests for authenticated connector-routing preflight API."""
+from __future__ import annotations
+
+import importlib.util
+import hashlib
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from lumina.auth import auth
+from lumina.persistence.adapter import NullPersistenceAdapter
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class _RecordingPersistence(NullPersistenceAdapter):
+    def __init__(self) -> None:
+        super().__init__()
+        self.records: list[dict] = []
+
+    def append_log_record(self, session_id, record, ledger_path=None) -> None:
+        self.records.append(dict(record))
+        super().append_log_record(session_id, record, ledger_path)
+
+
+def _load_api_module():
+    module_path = _REPO_ROOT / "src" / "lumina" / "api" / "server.py"
+    module_name = "lumina.api.server"
+    spec = importlib.util.spec_from_file_location(module_name, str(module_path))
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Could not load lumina-api-server module")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _install_embedder_stub() -> None:
+    """Provide a lightweight embedder module so API import stays hermetic in tests."""
+    fake = types.ModuleType("lumina.retrieval.embedder")
+
+    @dataclass(frozen=True)
+    class _DocChunk:
+        source_path: str
+        heading: str
+        text: str
+        content_hash: str
+        content_type: str = "document"
+        domain_id: str | None = None
+        organization_id: str | None = None
+        site_id: str | None = None
+        actor_id: str | None = None
+        device_id: str | None = None
+        record_type: str | None = None
+        record_id: str | None = None
+        thread_id: str | None = None
+        provider: str | None = None
+        external_record_type: str | None = None
+        external_record_id: str | None = None
+        module_key: str | None = None
+        created_utc: str | None = None
+
+        @staticmethod
+        def compute_hash(content: str) -> str:
+            return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+    class _DocEmbedder:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def embed_chunks(self, chunks):
+            return []
+
+        def embed_query(self, query):
+            return []
+
+    fake.EMBEDDING_DIM = 384
+    fake.DocChunk = _DocChunk
+    fake.DocEmbedder = _DocEmbedder
+    sys.modules["lumina.retrieval.embedder"] = fake
+
+
+def _install_vector_store_stub() -> None:
+    """Provide a minimal vector store module to avoid optional numpy imports."""
+    fake = types.ModuleType("lumina.retrieval.vector_store")
+
+    class _SearchResult:
+        def __init__(self, chunk, score: float) -> None:
+            self.chunk = chunk
+            self.score = score
+
+    class _VectorStore:
+        def __init__(self, *args, **kwargs) -> None:
+            self.size = 0
+
+        def load(self) -> None:
+            return None
+
+        def save(self) -> None:
+            return None
+
+        def add(self, chunks, vectors) -> None:
+            self.size = len(chunks)
+
+        def has_hash(self, _content_hash: str) -> bool:
+            return False
+
+        def search(self, *args, **kwargs):
+            return []
+
+    fake.SearchResult = _SearchResult
+    fake.VectorStore = _VectorStore
+    sys.modules["lumina.retrieval.vector_store"] = fake
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("LUMINA_RUNTIME_CONFIG_PATH", "model-packs/education/cfg/runtime-config.yaml")
+    monkeypatch.delenv("LUMINA_DOMAIN_REGISTRY_PATH", raising=False)
+    _install_embedder_stub()
+    _install_vector_store_stub()
+    mod = _load_api_module()
+    persistence = _RecordingPersistence()
+    mod.PERSISTENCE = persistence
+    monkeypatch.setattr(auth, "JWT_SECRET", "test-secret")
+    return TestClient(mod.app), persistence
+
+
+def _token(*, organization_id: str | None = "org-a", site_id: str | None = "site-a") -> str:
+    return auth.create_scoped_jwt(
+        user_id="actor-a",
+        role="user",
+        organization_id=organization_id,
+        site_id=site_id,
+    )
+
+
+def _preflight_payload() -> dict:
+    return {
+        "request_id": "req-1",
+        "action_class": "query",
+        "capability_namespace": "service/work-order",
+        "connector_registry_entries": [
+            {
+                "organization_id": "org-a",
+                "site_id": "site-a",
+                "connector_instance_id": "conn-a",
+                "capability_namespaces": ["service/work-order"],
+                "supported_action_classes": ["query"],
+                "enabled": True,
+                "health_status": "healthy",
+                "is_site_primary": True,
+            }
+        ],
+        "capability_routes": [
+            {
+                "capability_namespace": "service/work-order",
+                "connector_instance_id": "conn-a",
+                "supported_action_classes": ["query"],
+                "priority": 1,
+            }
+        ],
+        "policy_version": 1,
+        "session_id": "session-1",
+    }
+
+
+@pytest.mark.integration
+def test_preflight_returns_scoped_resolution_and_persists_trace_event(client) -> None:
+    test_client, persistence = client
+    response = test_client.post(
+        "/api/connector-routing/preflight",
+        headers={"Authorization": f"Bearer {_token()}"},
+        json=_preflight_payload(),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "resolved"
+    assert body["source"] == "capability_route"
+    assert body["connector_instance_id"] == "conn-a"
+    assert len(persistence.records) == 1
+    trace = persistence.records[0]
+    assert trace["record_type"] == "TraceEvent"
+    evidence = trace.get("evidence_summary", {})
+    assert evidence["connector_resolution_result"]["request_id"] == "req-1"
+    assert "transcript" not in str(evidence).lower()
+
+
+@pytest.mark.integration
+def test_preflight_rejects_unscoped_token(client) -> None:
+    test_client, _ = client
+    response = test_client.post(
+        "/api/connector-routing/preflight",
+        headers={"Authorization": f"Bearer {_token(organization_id=None, site_id=None)}"},
+        json=_preflight_payload(),
+    )
+
+    assert response.status_code == 403
+
+
+@pytest.mark.integration
+def test_preflight_rejects_cross_scope_registry_entry(client) -> None:
+    test_client, _ = client
+    payload = _preflight_payload()
+    payload["connector_registry_entries"][0]["site_id"] = "site-b"
+    response = test_client.post(
+        "/api/connector-routing/preflight",
+        headers={"Authorization": f"Bearer {_token()}"},
+        json=payload,
+    )
+
+    assert response.status_code == 403
+
+
+@pytest.mark.integration
+def test_preflight_returns_missing_idempotency_for_mutation(client) -> None:
+    test_client, _ = client
+    payload = _preflight_payload()
+    payload["action_class"] = "request_commit"
+    payload["connector_registry_entries"][0]["supported_action_classes"] = ["request_commit"]
+    payload["capability_routes"][0]["supported_action_classes"] = ["request_commit"]
+
+    response = test_client.post(
+        "/api/connector-routing/preflight",
+        headers={"Authorization": f"Bearer {_token()}"},
+        json=payload,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "error"
+    assert response.json()["reason_code"] == "missing_idempotency_key"

--- a/tests/test_connector_routing_api.py
+++ b/tests/test_connector_routing_api.py
@@ -39,8 +39,8 @@ def _load_api_module():
     return mod
 
 
-def _install_embedder_stub() -> None:
-    """Provide a lightweight embedder module so API import stays hermetic in tests."""
+def _build_embedder_stub() -> types.ModuleType:
+    """Build a lightweight embedder module so API import stays hermetic in tests."""
     fake = types.ModuleType("lumina.retrieval.embedder")
 
     @dataclass(frozen=True)
@@ -81,11 +81,11 @@ def _install_embedder_stub() -> None:
     fake.EMBEDDING_DIM = 384
     fake.DocChunk = _DocChunk
     fake.DocEmbedder = _DocEmbedder
-    sys.modules["lumina.retrieval.embedder"] = fake
+    return fake
 
 
-def _install_vector_store_stub() -> None:
-    """Provide a minimal vector store module to avoid optional numpy imports."""
+def _build_vector_store_stub() -> types.ModuleType:
+    """Build a minimal vector store module to avoid optional numpy imports."""
     fake = types.ModuleType("lumina.retrieval.vector_store")
 
     class _SearchResult:
@@ -114,20 +114,26 @@ def _install_vector_store_stub() -> None:
 
     fake.SearchResult = _SearchResult
     fake.VectorStore = _VectorStore
-    sys.modules["lumina.retrieval.vector_store"] = fake
+    return fake
 
 
 @pytest.fixture
 def client(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("LUMINA_RUNTIME_CONFIG_PATH", "model-packs/education/cfg/runtime-config.yaml")
     monkeypatch.delenv("LUMINA_DOMAIN_REGISTRY_PATH", raising=False)
-    _install_embedder_stub()
-    _install_vector_store_stub()
+    monkeypatch.setitem(sys.modules, "lumina.retrieval.embedder", _build_embedder_stub())
+    monkeypatch.setitem(sys.modules, "lumina.retrieval.vector_store", _build_vector_store_stub())
+    prior_server_module = sys.modules.get("lumina.api.server")
     mod = _load_api_module()
     persistence = _RecordingPersistence()
     mod.PERSISTENCE = persistence
     monkeypatch.setattr(auth, "JWT_SECRET", "test-secret")
-    return TestClient(mod.app), persistence
+    try:
+        yield TestClient(mod.app), persistence
+    finally:
+        sys.modules.pop("lumina.api.server", None)
+        if prior_server_module is not None:
+            sys.modules["lumina.api.server"] = prior_server_module
 
 
 def _token(*, organization_id: str | None = "org-a", site_id: str | None = "site-a") -> str:
@@ -234,3 +240,52 @@ def test_preflight_returns_missing_idempotency_for_mutation(client) -> None:
     assert response.status_code == 200
     assert response.json()["status"] == "error"
     assert response.json()["reason_code"] == "missing_idempotency_key"
+
+
+@pytest.mark.integration
+def test_preflight_normalizes_action_and_health_values(client) -> None:
+    test_client, _ = client
+    payload = _preflight_payload()
+    payload["action_class"] = "  QUERY  "
+    payload["connector_registry_entries"][0]["health_status"] = "HEALTHY"
+    payload["connector_registry_entries"][0]["supported_action_classes"] = [" QUERY "]
+    payload["capability_routes"][0]["supported_action_classes"] = [" query "]
+
+    response = test_client.post(
+        "/api/connector-routing/preflight",
+        headers={"Authorization": f"Bearer {_token()}"},
+        json=payload,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "resolved"
+
+
+@pytest.mark.integration
+def test_preflight_rejects_unsupported_health_status(client) -> None:
+    test_client, _ = client
+    payload = _preflight_payload()
+    payload["connector_registry_entries"][0]["health_status"] = "unknown"
+
+    response = test_client.post(
+        "/api/connector-routing/preflight",
+        headers={"Authorization": f"Bearer {_token()}"},
+        json=payload,
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.integration
+def test_preflight_rejects_unsupported_action_class(client) -> None:
+    test_client, _ = client
+    payload = _preflight_payload()
+    payload["action_class"] = "delete_forever"
+
+    response = test_client.post(
+        "/api/connector-routing/preflight",
+        headers={"Authorization": f"Bearer {_token()}"},
+        json=payload,
+    )
+
+    assert response.status_code == 422


### PR DESCRIPTION
## 🛑 Wait! Before You Submit...
Project Lumina operates on a strict **Accountability by Design** philosophy. We do not merge code based on "vibes" or isolated LLM testing. Your PR must mathematically prove that it respects the Dynamic Prompt Contracts and maintains the integrity of the Causal Trace Ledger (CTL).

### 📋 Architectural Compliance Checklist

- [ ] **Tests Passed:** I have successfully run `run-preintegration-scenarios.ps1` and all deterministic tests passed.
- [x] **CTL Integrity:** My changes do not break the append-only hash-chain. Every new decision path correctly generates a `TraceEvent` or `EscalationRecord`.
- [x] **Domain Separation:** If modifying the core engine (`reference-implementations/`), I have ensured my code contains zero domain-specific logic or hardcoded subjects.
- [x] **Pseudonymity:** My changes do not introduce the storage of raw chat transcripts or personally identifiable information (PII) at rest.
- [x] **Traceability Proof:** I have attached a sample `TraceEvent` payload below that demonstrates feature logging.

---

## 📝 Description of Changes

Implements Slice 31 PR2 API wiring for connector routing preflight and audit evidence.

- Added authenticated, scope-safe endpoint: `POST /api/connector-routing/preflight`
- Added request/response API models for connector registry entries, route policy inputs, and preflight results
- Enforced active operating-context boundaries for all registry entries (organization/site match required)
- Wired deterministic connector resolution through `resolve_connector(...)`
- Appended transcript-free `TraceEvent` evidence with `connector_resolution_result` into System Log ledger
- Registered the new router in API server startup
- Added integration tests covering:
  - successful scoped resolution and trace logging
  - unscoped token rejection
  - cross-scope registry entry rejection
  - mutation-class request without idempotency key returning structured error status

## 🔄 Type of Change

- [ ] ⚙️ **Core Engine** (Changes to the domain-agnostic orchestrator)
- [x] 📦 **Domain Pack** (New domain physics, runtime configs, or schemas)
- [ ] 🛠️ **Tool Adapter** (New deterministic tools for verification/evidence extraction)
- [x] 🛡️ **Governance/Security** (Changes to CTL, auditing, or escalation paths)
- [ ] 📖 **Documentation** (Updates to specs, READMEs, or guides)

---

## 🧪 Traceability Proof (Mandatory)

```json
{
  "record_type": "TraceEvent",
  "record_id": "<uuid>",
  "prev_record_hash": "genesis",
  "timestamp_utc": "2026-07-30T00:00:00Z",
  "session_id": "connector-routing",
  "actor_id": "actor-a",
  "event_type": "other",
  "decision": "connector_routing_evaluated",
  "evidence_summary": {
    "connector_resolution_result": {
      "resolution_id": "<uuid>",
      "request_id": "req-1",
      "organization_id": "org-a",
      "site_id": "site-a",
      "actor_id": "actor-a",
      "action_class": "query",
      "capability_namespace": "service/work-order",
      "status": "resolved",
      "source": "capability_route",
      "reason_code": "route_match",
      "connector_instance_id": "conn-a",
      "idempotency_key": null,
      "correlation_id": null,
      "policy_version": 1,
      "candidate_connector_ids": ["conn-a"],
      "evaluated_utc": "2026-07-30T00:00:00Z"
    }
  }
}
```

## ✅ Validation Performed

- `pytest tests/test_connector_routing.py tests/test_connector_routing_contracts.py tests/test_connector_routing_api.py -q`
- Result: `18 passed`

---

## 🌍 Domain Impact (For Core Changes Only)

Not a core orchestrator change.
