### PR TITLE
docs(roadmap): synchronize non-delivered slices to active alignment thread

### DIFF
--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -1,13 +1,13 @@
 ---
-version: 1.2.6
-last_updated: 2026-08-03
+version: 1.2.7
+last_updated: 2026-08-04
 ---
 
 # Lumina Framework Roadmap
 
-**Version:** 1.2.6
+**Version:** 1.2.7
 **Status:** Active
-**Last updated:** 2026-08-03
+**Last updated:** 2026-08-04
 
 ---
 
@@ -79,6 +79,17 @@ invariants it established.
 ## Direction Lock
 
 Slice 39 hard-locks the ERP integration direction to a reusable generic service core with profile-layer variance. Until explicitly superseded, new vertical onboarding work should extend profile and mapping layers first rather than introducing core workflow forks.
+
+## Active Alignment Thread (2026-08-04)
+
+Current active slices and planned slices align to the following execution thread:
+
+- DAG/task dependency logic remains domain-pack internal.
+- `task_ready_for_execution` is treated as current node/task readiness, not whole-workflow completion.
+- Missing prerequisites route to bounded information acquisition (actor prompts, ERP lookups, scoped institutional memory retrieval).
+- Institutional memory records must support grouping similar decisions and linking customer/client/entity state transitions through stable record linkage metadata.
+
+This thread is carried through non-delivered slices 01-06, 25, 29, 36, 37, 38, and 39.
 
 ---
 

--- a/docs/roadmap/slices/01-framework-boundary.md
+++ b/docs/roadmap/slices/01-framework-boundary.md
@@ -1,13 +1,13 @@
 ---
-version: 1.0.0
-last_updated: 2026-05-05
+version: 1.0.1
+last_updated: 2026-08-04
 ---
 
 # Slice 1: Framework Boundary and Final Shape Documentation
 
-**Version:** 1.0.0
+**Version:** 1.0.1
 **Status:** Active
-**Last updated:** 2026-05-05
+**Last updated:** 2026-08-04
 **PR:** This document is itself the primary deliverable of Slice 1.
 
 ---
@@ -43,6 +43,11 @@ must be documented clearly and unambiguously.
   PR does not perform that work.
 - Establish the PR-per-slice roadmap convention so later PRs can continue from
   Slice 2.
+
+## 2026-08-04 Alignment Addendum
+
+- Preserve framework boundary: DAG/task graph internals are domain-pack owned and are not promoted into `src/lumina/` host logic.
+- Preserve host contract: core runtime consumes generic readiness/status signals only.
 
 ---
 

--- a/docs/roadmap/slices/02-system-update-vocabulary.md
+++ b/docs/roadmap/slices/02-system-update-vocabulary.md
@@ -1,13 +1,13 @@
 ---
-version: 1.0.0
-last_updated: 2026-05-06
+version: 1.0.1
+last_updated: 2026-08-04
 ---
 
 # Slice 2: System Update Vocabulary
 
-**Version:** 1.0.0
+**Version:** 1.0.1
 **Status:** Active
-**Last updated:** 2026-05-06
+**Last updated:** 2026-08-04
 **PR:** This document is itself the primary deliverable of Slice 2.
 
 ---
@@ -37,6 +37,11 @@ behaviour described by these terms; this slice only names and contracts them.
   correctness ≠ governance approval, activation ownership).
 - Update the roadmap index so Slice 2 is discoverable.
 - Register the new file in `docs/MANIFEST.yaml`.
+
+## 2026-08-04 Alignment Addendum
+
+- `BuildResult` and downstream lifecycle terms should not reinterpret `task_ready_for_execution` as workflow-complete; treat it as node/task readiness only.
+- Missing-information acquisition is a first-class route: actor clarification, ERP lookup, or scoped institutional-memory retrieval before denial/escalation.
 
 ---
 

--- a/docs/roadmap/slices/03-request-intake-and-classification.md
+++ b/docs/roadmap/slices/03-request-intake-and-classification.md
@@ -1,13 +1,13 @@
 ---
-version: 1.0.0
-last_updated: 2026-05-07
+version: 1.0.1
+last_updated: 2026-08-04
 ---
 
 # Slice 3: Request Intake and Classification
 
-**Version:** 1.0.0
+**Version:** 1.0.1
 **Status:** Active
-**Last updated:** 2026-05-07
+**Last updated:** 2026-08-04
 **PR:** This document is itself the primary deliverable of Slice 3.
 
 ---
@@ -41,6 +41,11 @@ Coding Agent. It does not mutate system state.
 - Register the new file in `docs/MANIFEST.yaml`.
 - Optionally add lightweight enum/type scaffolding if the repository already
   has a schema/contracts convention (minimal, aligned with existing patterns).
+
+## 2026-08-04 Alignment Addendum
+
+- Classification should surface explicit "missing prerequisite information" outcomes that route to bounded acquisition rather than silent failure.
+- Domain DAG/task-graph semantics remain downstream/domain-owned; classification remains host-generic.
 
 ---
 

--- a/docs/roadmap/slices/04-system-pack-authority-gate.md
+++ b/docs/roadmap/slices/04-system-pack-authority-gate.md
@@ -1,13 +1,13 @@
 ---
-version: 1.0.0
-last_updated: 2026-05-07
+version: 1.0.1
+last_updated: 2026-08-04
 ---
 
 # Slice 4: System Pack Authority Gate
 
-**Version:** 1.0.0
+**Version:** 1.0.1
 **Status:** Active
-**Last updated:** 2026-05-07
+**Last updated:** 2026-08-04
 **PR:** This document is itself the primary deliverable of Slice 4.
 
 ---
@@ -35,6 +35,11 @@ typed request context; it does not grant authority.
 - Register the new file in `docs/MANIFEST.yaml`.
 - Optionally add lightweight enum/type scaffolding only if a repository
   schema/contracts convention already exists.
+
+## 2026-08-04 Alignment Addendum
+
+- Authority outcomes should differentiate "not authorized" from "authorized but missing information" so operational flow can continue via bounded acquisition.
+- Decisions should not infer workflow completion from task/node readiness signals.
 
 ---
 

--- a/docs/roadmap/slices/05-system-pack-sole-coding-agent-ingress.md
+++ b/docs/roadmap/slices/05-system-pack-sole-coding-agent-ingress.md
@@ -1,13 +1,13 @@
 ---
-version: 1.0.0
-last_updated: 2026-05-07
+version: 1.0.1
+last_updated: 2026-08-04
 ---
 
 # Slice 5: System Pack as Sole Coding Agent Ingress
 
-**Version:** 1.0.0
+**Version:** 1.0.1
 **Status:** Active
-**Last updated:** 2026-05-07
+**Last updated:** 2026-08-04
 **PR:** This document is itself the primary deliverable of Slice 5.
 
 ---
@@ -34,6 +34,11 @@ work.
 - Preserve governance/safety invariants for authority, scoping, templating,
   staging, and activation boundaries.
 - Update roadmap discoverability and manifest entries for this slice.
+
+## 2026-08-04 Alignment Addendum
+
+- Sole-ingress enforcement remains orthogonal to domain DAG orchestration; DAG internals stay in the domain pack.
+- Ingress denials should explicitly support "needs_information" routing to actor/ERP/institutional-memory acquisition before escalation where policy allows.
 
 ---
 

--- a/docs/roadmap/slices/06-coding-agent-model-pack-architecture-v2.md
+++ b/docs/roadmap/slices/06-coding-agent-model-pack-architecture-v2.md
@@ -1,13 +1,13 @@
 ---
-version: 1.0.0
-last_updated: 2026-06-19
+version: 1.0.1
+last_updated: 2026-08-04
 ---
 
 # Slice 6: Coding Agent Model Pack Architecture V2
 
-**Version:** 1.0.0
+**Version:** 1.0.1
 **Status:** Active
-**Last updated:** 2026-06-19
+**Last updated:** 2026-08-04
 **PR:** This document is itself the primary deliverable of Slice 6.
 
 ---
@@ -38,6 +38,12 @@ slice.
 - Preserve the System Pack-only ingress invariant established in Slice 5.
 - Keep the architecture hardware-neutral and provider-neutral.
 - Update roadmap discoverability and manifest entries for this slice.
+
+## 2026-08-04 Alignment Addendum
+
+- Architecture remains host-generic: domain DAG dependencies and ready-node evaluation are domain-pack responsibilities.
+- `task_ready_for_execution` must be interpreted as current task/node readiness only.
+- Experiential/institutional memory contracts should support grouping similar decisions and linking entity state transitions via stable record linkage metadata.
 
 ---
 

--- a/docs/roadmap/slices/25-b2b-workstream-boundary-and-task-graph.md
+++ b/docs/roadmap/slices/25-b2b-workstream-boundary-and-task-graph.md
@@ -2,8 +2,8 @@
 title: "Slice 25 — B2B Workstream Boundary and Global Task Graph"
 slice: 25
 status: planned
-version: 0.1.0
-last_updated: 2026-07-11
+version: 0.1.1
+last_updated: 2026-08-04
 ---
 
 ## Purpose
@@ -15,6 +15,12 @@ Define the implementation boundary for the `b2b-institutional-memory-business-sy
 - Formalize the global task graph and phase order for the B2B workstream.
 - Record explicit system boundaries: external system state ownership, Lumina memory ownership, and governance constraints.
 - Define non-negotiable constraints for credentials, transcript handling, and deterministic test posture.
+
+## 2026-08-04 Alignment Addendum
+
+- Global task graph semantics remain domain-owned orchestration behavior; host services remain graph-agnostic.
+- Runtime readiness semantics treat `task_ready_for_execution` as current node/task readiness only.
+- Missing-prerequisite branches should route to bounded information acquisition (actor clarification, ERP retrieval, scoped institutional memory) before escalation when policy permits.
 
 ## Out of Scope
 

--- a/docs/roadmap/slices/29-decision-precedent-confidence-and-escalation.md
+++ b/docs/roadmap/slices/29-decision-precedent-confidence-and-escalation.md
@@ -2,8 +2,8 @@
 title: "Slice 29 — Decision Precedent, Confidence, and Escalation"
 slice: 29
 status: planned
-version: 0.2.0
-last_updated: 2026-07-20
+version: 0.2.1
+last_updated: 2026-08-04
 ---
 
 ## Purpose
@@ -30,6 +30,12 @@ permits and create a human-approval packet when confidence or risk requires it.
   record IDs, policy version, component scores, and selected tier.
 - Reuse existing System Log `EscalationRecord` lifecycle for mandatory
   escalation; Slice 29 creates evidence and a pending approval request only.
+
+## 2026-08-04 Alignment Addendum
+
+- Decision precedent routing remains compatible with domain-owned DAG/task orchestration; host/core stays generic.
+- Precedent and escalation evidence should include stable linkage metadata for grouping similar decision classes and tracing entity state transitions over time.
+- Missing-information cases must be explicit confidence inputs and route to bounded acquisition paths before forced escalation when policy permits.
 
 ## Out of Scope
 

--- a/docs/roadmap/slices/36-single-box-deployment-and-operational-hardening.md
+++ b/docs/roadmap/slices/36-single-box-deployment-and-operational-hardening.md
@@ -2,8 +2,8 @@
 title: "Slice 36 — Single-Box Deployment and Operational Hardening"
 slice: 36
 status: planned
-version: 0.2.0
-last_updated: 2026-08-03
+version: 0.2.1
+last_updated: 2026-08-04
 ---
 
 ## Purpose
@@ -17,6 +17,11 @@ Define and validate the single-box deployment profile for pilot rollout, includi
 - Define backup/restore and local retention controls for institutional memory artifacts.
 - Define operator runbooks for route failures, connector degradation, and escalation backlog handling.
 - Preserve Slice 39 generic service-core invariants so vertical variation remains profile/presentation-level during hardening work.
+
+## 2026-08-04 Alignment Addendum
+
+- Operational hardening must preserve domain-owned task-graph orchestration boundaries and keep host runtime graph-agnostic.
+- Degraded-mode runbooks should include missing-information acquisition order (actor prompt -> ERP lookup -> scoped institutional retrieval) before escalation.
 
 ## Out of Scope
 

--- a/docs/roadmap/slices/37-erp-identity-authority-and-claim-contract.md
+++ b/docs/roadmap/slices/37-erp-identity-authority-and-claim-contract.md
@@ -2,8 +2,8 @@
 title: "Slice 37 — ERP Identity Authority and Claim Contract"
 slice: 37
 status: active
-version: 0.1.0
-last_updated: 2026-08-03
+version: 0.1.1
+last_updated: 2026-08-04
 ---
 
 ## Purpose
@@ -18,6 +18,11 @@ Establish ERP as the single source of truth (SSOT) for non-system identity and a
 - Define issuer, audience, expiry, and key-rotation contract requirements.
 - Define required role/context mapping from ERP claims into Lumina authorization checks.
 - Define break-glass and outage posture for temporary fallback and audit requirements.
+
+## 2026-08-04 Alignment Addendum
+
+- Claim contracts should preserve sufficient scoped linkage fields to connect identity decisions with institutional-memory decision groups and entity state traces.
+- Authorization outcomes should distinguish denied-from-policy vs missing-information-required routing for deterministic follow-up behavior.
 
 ## Out of Scope
 

--- a/docs/roadmap/slices/38-erp-jwt-verification-gateway-and-auth-transition.md
+++ b/docs/roadmap/slices/38-erp-jwt-verification-gateway-and-auth-transition.md
@@ -2,8 +2,8 @@
 title: "Slice 38 — ERP JWT Verification Gateway and Auth Transition"
 slice: 38
 status: planned
-version: 0.1.0
-last_updated: 2026-08-03
+version: 0.1.1
+last_updated: 2026-08-04
 ---
 
 ## Purpose
@@ -17,6 +17,11 @@ Implement Lumina runtime verification of ERP-issued JWTs for domain/user tracks 
 - Define domain/user middleware transition from Lumina-issued tokens to ERP-issued tokens.
 - Define compatibility/deprecation schedule for legacy domain/user login endpoints.
 - Keep system-track login and token issuance (`/api/admin/auth/*`) in Lumina.
+
+## 2026-08-04 Alignment Addendum
+
+- Verification and transition flows should retain identity/context metadata needed for scoped institutional-memory linkage and decision traceability.
+- Auth failures due to missing claims should map to deterministic missing-information acquisition or denial outcomes per policy, not ambiguous terminal states.
 
 ## Out of Scope
 

--- a/docs/roadmap/slices/39-generic-erp-service-core-and-vertical-profile-layer.md
+++ b/docs/roadmap/slices/39-generic-erp-service-core-and-vertical-profile-layer.md
@@ -2,8 +2,8 @@
 title: "Slice 39 — Generic ERP Service Core and Vertical Profile Layer"
 slice: 39
 status: planned
-version: 0.1.0
-last_updated: 2026-08-03
+version: 0.1.1
+last_updated: 2026-08-04
 ---
 
 ## Purpose
@@ -17,6 +17,12 @@ Lock the reusable ERP integration direction by defining one canonical service wo
 - Isolate ERP provider specifics to thin mapping adapters.
 - Define optional low-change customization hooks (for example custom doctype/table mappings) that do not alter canonical contracts.
 - Define parity expectations across at least ERPNext and Odoo for identical canonical operations.
+
+## 2026-08-04 Alignment Addendum
+
+- Canonical service-core flow remains host-generic while domain profile orchestration (including DAG/task dependency handling) stays in the domain/profile layer.
+- `task_ready_for_execution` semantics are node/task readiness only and must not be overloaded as workflow-terminal state.
+- Profile parity evidence should include linkage metadata that groups similar decisions and tracks entity state transitions across profiles/providers.
 
 ## Out of Scope
 


### PR DESCRIPTION
## Scope\n- Sync roadmap index and non-delivered slices to the active alignment thread.\n- Add explicit DAG-in-pack semantics, node-readiness language, and missing-information routing notes.\n\n## Files\n- docs/roadmap/README.md\n- docs/roadmap/slices/01,02,03,04,05,06,25,29,36,37,38,39\n\n## Review note\n- This PR is intentionally stacked on PR #1 to keep concept semantics and roadmap sync separately reviewable.